### PR TITLE
NTBS-584: Remove deleted notifications from the notification cluster view

### DIFF
--- a/source/dbo/Views/ClusterMatching/vwNotificationClusterMatch.sql
+++ b/source/dbo/Views/ClusterMatching/vwNotificationClusterMatch.sql
@@ -34,6 +34,7 @@ CREATE VIEW [dbo].[vwNotificationClusterMatch]
 		FROM [$(NTBS)].[dbo].[Notification] n2
 		LEFT OUTER JOIN [dbo].[NotificationClusterMatch] ncm2
 			ON n2.NotificationId = ncm2.NotificationId
-		WHERE 
-			n2.ClusterId IS NOT NULL
+		WHERE
+			n2.NotificationStatus <> 'Deleted'
+			AND n2.ClusterId IS NOT NULL
 			AND ncm2.NotificationId IS NULL


### PR DESCRIPTION
Remove deleted notifications from the 'set to null' side of the notification cluster update view.

Something to bear in mind is that if the job cannot find a notification (either it doesn't exist or is deleted, which we consider to be essentially the same thing) then the recurring job will fail. If you would like us to handle this a different way, please let us know.