### PR TITLE
NTBS-NONE Use per-developer databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ DocProject/Help/html
 publish/
 
 # Publish Web Output
-*.[Pp]ublish.xml
+source/azure-ntbs-USER-reporting.publish.xml
 *.azurePubxml
 # TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ To make a new copy of the reporting database, do the following:
     1. In the pop-up window, next to the `Target database connection` select `Edit...`, and enter the password for the `sqlAdmin` user - this can be found in the `ntbs-ops-dbs-credentials` secret in Azure. (If you also check `Remember password` then you do not need to repeat this step in future).
     2. Click `Generate Script`. Review the SQL script that is generated, and confirm that it is reflective of your changes. In this case, it should be creating all of the tables, and adding all of the functions and stored procedures.
     3. When you are happy with this script, double click on the xml file again and then click `Publish` in the dialog box that pops up. This will generate the same script again, and then run it on the SQL server, creating your new database in the process.
-4. To populate the database, first run `uspPopulateCalendarTable`, and then run `uspGenerate`. This database is now ready for use.
+4. To populate the database:
+    1. Run the stored procedure `uspPopulateCalendarTable`
+    2. Run the a SQL command based on the script in `source/Scripts/PopulateFeatureFlags.sql`. To make a dev database, you will want to set the three numbers being inserted to `1, 1, 1` instead of the default `0, 0, 0`.
+    3. Run the stored procedure `uspGenerate`
 
 To make a change to the project you should then:
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
 ## Developer guide
 
 This database project is dependent upon multiple other databases to work correctly. At the time of writing, there is no easy way to restore a local copy of each of these dependencies. Moreover, the project requires the databases to all run on the same instance of SQL Server, meaning that we do not currently have a way to set up a local development environment for this project.
-
-In most cases, development should be done against the `int` environment on the `ntbs-ops-dbs` server. Since it may be difficult to resolve conflicts with multiple developers working against the same database, the currently recommended branching strategy is to commit changes directly onto the `master` branch.
+However, it is possible to set up a new reporting database in this environment, to do your development against in a feature branch. In most cases, the dependencies of the reporting databases should be the `int` versions of the relevant databases (`int-geography`, `int-ntbs`, etc.)
 
 Make sure that you have the following tools installed locally:
 
 - Visual Studio 2017 (or later) - this can be downloaded from https://visualstudio.microsoft.com/downloads/
-	- During installation, select “Data storage and processing”
+	- During installation, select "Data storage and processing"
 
 - Git - this can be downloaded from https://git-scm.com/downloads
 
 You can then begin working on the project by cloning the repository and opening `VisualStudio_ntbs-reporting.sln` in Visual Studio.
 
+To make a new copy of the reporting database, do the following:
+1. Make a copy of `azure-ntbs-int-reporting.publish.xml` and name it `azure-ntbs-USER-reporting.publish.xml`. This file will be ignored by Git.
+2. Edit this file, replacing the `TargetDatabaseName` value with the name of the new reporting database you would like to create. This database should not exist on the Azure SQL Server yet.
+3. Publish this database, by double clicking on the xml file in the VS Solution explorer:
+    1. In the pop-up window, next to the `Target database connection` select `Edit...`, and enter the password for the `sqlAdmin` user - this can be found in the `ntbs-ops-dbs-credentials` secret in Azure. (If you also check `Remember password` then you do not need to repeat this step in future).
+    2. Click `Generate Script`. Review the SQL script that is generated, and confirm that it is reflective of your changes. In this case, it should be creating all of the tables, and adding all of the functions and stored procedures.
+    3. When you are happy with this script, double click on the xml file again and then click `Publish` in the dialog box that pops up. This will generate the same script again, and then run it on the SQL server, creating your new database in the process.
+4. To populate the database, first run `uspPopulateCalendarTable`, and then run `uspGenerate`. This database is now ready for use.
+
 To make a change to the project you should then:
 
 1. Create or update the relevant table, function, stored procedure, etc. in the appropriate directory.
+2. Go through step 3 of making a new copy to publish the changes to your database.
+3. Run `uspGenerate` on the newly published changes.
 
-1. In the `Solution Explorer` window, double click on the `azure-ntbs-int-reporting.publish.xml` file.
+To release changes:
 
-1. In the pop-up window, next to the `Target database connection` select `Edit...`, and enter the password for the `sqlAdmin` user - this can be found in the `ntbs-ops-dbs-credentials` secret in Azure. (If you also check `Remember password` then you do not need to repeat this step in future).
-
-1. Click `Generate Script`. Review the SQL script that is generated, and confirm that it is reflective of your changes.
-
-1. Double click on the `azure-ntbs-int-reporting.publish.xml` file again, and this time select `Publish`. This will push your change to the `int` database.
-
-1. Commit the change in git and push straight to the `master` branch.
+1. Push your changes to a feature branch, and open a pull request.
+2. Once this has been merged into `master`, the changes can be published to other databases for QA and active use using the relevant `publish.xml` scripts for each database.
 
 ## Coding standards
 

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -425,6 +425,7 @@
     <None Include="LIVE-phe-ntbs-R1Live-reporting.publish.xml" />
     <None Include="Scripts\PopulateFeatureFlags.sql" />
     <None Include="Scripts\ReviewProblemSpecimenMatch.sql" />
+    <None Include="azure-ntbs-USER-reporting.publish.xml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\Script.PostDeployment.sql" />


### PR DESCRIPTION
### Description
Update the README, add support for a per-developer publishing script in the `.sqlproj` file, and ignore this script in source control.

### Testing
No formal testing required, though this is based on me going through the process of setting up a new reporting database with Nancy.