### PR TITLE
NTBS-1664 Check for nulls when setting treatment regimen

### DIFF
--- a/source/dbo/Stored Procedures/Reusable Notification/uspGenerateReusableNotificationTreatmentRegimen_ETS.sql
+++ b/source/dbo/Stored Procedures/Reusable Notification/uspGenerateReusableNotificationTreatmentRegimen_ETS.sql
@@ -35,7 +35,7 @@ AS
 	WHERE NotificationId IN (SELECT n.LegacyId
 							 FROM [$(ETS)].dbo.Notification n
 								 INNER JOIN [$(ETS)].dbo.TreatmentPlanned tp ON tp.Id = n.TreatmentPlannedId
-							 WHERE tp.ShortCourseTreatment = 1 AND tp.MDRTreatment <> 1)
+							 WHERE tp.ShortCourseTreatment = 1 AND COALESCE(tp.MDRTreatment, 0) <> 1)
 
 
 	UPDATE dbo.ReusableNotification_ETS
@@ -43,7 +43,7 @@ AS
 	WHERE NotificationId IN (SELECT n.LegacyId
 							 FROM [$(ETS)].dbo.Notification n
 								 INNER JOIN [$(ETS)].dbo.TreatmentPlanned tp ON tp.Id = n.TreatmentPlannedId
-							 WHERE tp.ShortCourseTreatment <> 1 AND tp.MDRTreatment = 1)
+							 WHERE COALESCE(tp.ShortCourseTreatment, 0) <> 1 AND tp.MDRTreatment = 1)
 
 
 	UPDATE dbo.ReusableNotification_ETS
@@ -51,7 +51,7 @@ AS
 	WHERE NotificationId IN (SELECT n.LegacyId
 							 FROM [$(ETS)].dbo.Notification n
 								 INNER JOIN [$(ETS)].dbo.TreatmentPlanned tp ON tp.Id = n.TreatmentPlannedId
-							 WHERE (tp.ShortCourseTreatment <> 1 AND tp.MDRTreatment <> 1)
+							 WHERE (COALESCE(tp.ShortCourseTreatment, 0) <> 1 AND COALESCE(tp.MDRTreatment, 0) <> 1)
 								OR (tp.ShortCourseTreatment  = 1 AND tp.MDRTreatment  = 1))
 
 RETURN 0


### PR DESCRIPTION
### Description
When checking whether an ETS planned treatment is not equal to 1 (eg. `ShortCourseTreatment <> 1`), this condition also needs to return return if the value is `NULL`. Do this using `COALESCE` expressions.

### Testing
Tested on my Azure dev DB, found examples of this issue (eg. `EtsId = 142466`) and checked they no longer are present after the change. I've not deployed this anywhere else.