### PR TITLE
NTBS-2179: Add columns to reusable notification

### DIFF
--- a/source/dbo/Stored Procedures/Reusable Notification/uspGenerateReusableNotification.sql
+++ b/source/dbo/Stored Procedures/Reusable Notification/uspGenerateReusableNotification.sql
@@ -144,7 +144,10 @@ BEGIN TRY
 			  ,[QUIN]
 			  ,[MDR]
 			  ,[XDR]
-			  ,[DataRefreshedAt])
+			  ,[DataRefreshedAt]
+			  ,[Lat]
+			  ,[Long]
+			  ,[ClusterId])
 		SELECT
 			n.NotificationId								AS 'NotificationId'
 			,n.NotificationId								AS 'NTBS_ID'
@@ -322,7 +325,9 @@ BEGIN TRY
 			,NULL										    AS 'MDR'
 			,NULL										    AS 'XDR'
 			,GETUTCDATE()									AS 'DataRefreshedAt'
-
+			,NULL                                           AS 'Lat'
+			,NULL                                           AS 'Long'
+			,NULL                                           AS 'ClusterId'
 			FROM [$(NTBS)].[dbo].[Notification] n
 				LEFT OUTER JOIN [$(NTBS)].[dbo].[HospitalDetails] hd ON hd.NotificationId = n.NotificationId
 				LEFT OUTER JOIN [$(NTBS)].[dbo].[User] u ON u.Username = hd.CaseManagerUsername
@@ -641,6 +646,16 @@ BEGIN TRY
 
 
 		  EXEC [dbo].[uspMoveRecordsToLegacyExtract]
+
+
+		  UPDATE ReusableNotification
+		  SET
+			Lat = po.lat,
+			Long = po.long,
+			ClusterId = ncm.ClusterId
+		  FROM ReusableNotification rn
+		  LEFT JOIN [$(NTBS_R1_Geography_Staging)].[dbo].Reduced_Postcode_file po ON rn.Postcode = po.Pcode
+		  LEFT JOIN NotificationClusterMatch ncm ON rn.NotificationId = ncm.NotificationId
 
 	END TRY
 	BEGIN CATCH

--- a/source/dbo/Tables/Reusable Notification/ReusableNotification.sql
+++ b/source/dbo/Tables/Reusable Notification/ReusableNotification.sql
@@ -41,6 +41,8 @@
 	[ResidencePhec] [nvarchar](50) NULL,
 	[TreatmentPhecCode] [nvarchar] (50) NULL,
 	[TreatmentPhec] [nvarchar](50) NULL,
+	[Lat] [nvarchar](50) NULL,
+	[Long] [nvarchar](50) NULL,
 
 	-- Clinical Details
 	[SymptomOnsetDate] date NULL,
@@ -77,6 +79,7 @@
 	[TreatmentInUk] [varchar](30) NULL,
 	[PreviousId] [nvarchar](50) NULL,
 	[BcgVaccinated] [varchar](30) NULL,
+	[ClusterId] [nvarchar](20) NULL,
 
 	-- Risk Factors
 	[AnySocialRiskFactor] [varchar](40) NULL,


### PR DESCRIPTION
Added Lat, Long and ClusterId to reusable notification. Adding these meant that references to clusterId no longer need to be gotten from joins, so to be able to build this (without ambiguous reference errors) I removed those joins. 