### PR TITLE
NTBS-2188 Improve uspSeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ Steps:
 1. If the instance of SQL Server that you are using is not at `localhost` then update the `Data Source` in the `TargetConnectionString`.
 1. Double-click on this config in the `Solution Explorer` panel in Visual Studio to publish the codebase. This will build the relevant views and set up the relevant tables.
 1. To populate the database, do the following:
-    1. Run the stored procedure `uspSeed` in the specimen matching database.
     1. Run the stored procedure `uspPopulateCalendarTable` in the reporting database.
     1. Run the a SQL command based on the script in `source/Scripts/PopulateFeatureFlags.sql`. To make a dev database, you will want to set the three numbers being inserted to `1, 1, 1` instead of the default `0, 0, 0`.
     1. Run the stored procedure `uspLabSpecimen` in the reporting database.
     1. Run the stored procedure `uspGenerate` in the specimen matching database.
-        - If this fails, then try updating the `ProcessBatchConfig` table by setting the `EstimateNumOfMatches` in the first row to `5`.
-        - If this still fails, then try importing a dozen or so legacy notfications in the NTBS application.
+        - If this fails, then try creating at least three notfications in the NTBS application. At this point the NTBS application should run, but some Hangfire jobs and legacy notification importing will not work properly with unpopulated specimen matching and reporting databases.
     1. Run the stored procedure `uspGenerate` in the reporting database.
 
 To make a change to the project you should then:

--- a/source/Scripts/PopulateFeatureFlags.sql
+++ b/source/Scripts/PopulateFeatureFlags.sql
@@ -1,8 +1,0 @@
-﻿--this can be used to set up the ReportingFeatureFlags table in your chosen environment - set the values 
---according to what you need.  It assumes the table is currently empty
-
-IF (SELECT COUNT(1) FROM [dbo].[ReportingFeatureFlags]) = 0
-BEGIN
-	INSERT INTO [dbo].[ReportingFeatureFlags](IncludeNTBS, IncludeETS, IncludeLabBase, Comment)
-	VALUES(0, 0, 0, 'Include or exclude records from various datasources in the reporting database')
-END

--- a/source/dbo/uspSeed.sql
+++ b/source/dbo/uspSeed.sql
@@ -1,7 +1,7 @@
 ﻿
 /***************************************************************************************************
 Desc:    This seeds or re-seeds the look-up-data. It gets called from uspGenerate(),
-         so is run straight after every code deployment. If in doubt, you can also
+		 so is run straight after every code deployment. If in doubt, you can also
 		 run this proc stand-alone at any time, and it will re-seed the look-up data.
 
 
@@ -12,6 +12,20 @@ CREATE PROCEDURE [dbo].[uspSeed] AS
 	BEGIN TRY
 		-- If any errors, then roll back
 		BEGIN TRANSACTION
+
+		-- If the calendar has not been populated, do so
+		IF NOT EXISTS (SELECT 1 FROM [dbo].[Calendar])
+		BEGIN
+			EXEC uspPopulateCalendarTable
+		END
+
+		-- If the feature flags have not been set, set them
+		-- These include or exclude records from various datasources in the reporting database
+		IF NOT EXISTS (SELECT 1 FROM [dbo].[ReportingFeatureFlags])
+		BEGIN
+			INSERT INTO [dbo].[ReportingFeatureFlags](IncludeNTBS, IncludeETS, IncludeLabBase, Comment)
+			VALUES(1, 1, 1, 'Include or exclude records from various datasources in the reporting database')
+		END
 
 		-- Disable all foreign keys to make the inserts below succeedC:\Users\ntbsadmin\Desktop\phe-ntbs-summaries\visual-studio\dbo\uspDeploy.sql
 		DECLARE @SqlNocheck NVARCHAR(MAX) = ''

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -344,7 +344,6 @@
     <None Include="phe-ntbs-live-reporting.publish.xml" />
     <None Include="DEV-USER-reporting.publish.xml" />
     <None Include="LIVE-phe-ntbs-R1Live-reporting.publish.xml" />
-    <None Include="Scripts\PopulateFeatureFlags.sql" />
     <None Include="Scripts\ReviewProblemSpecimenMatch.sql" />
     <None Include="azure-ntbs-int-reporting.publish.xml" />
     <None Include="DEV-reporting.publish.xml" />


### PR DESCRIPTION
### Changes
* Update README: NTBS-2188 specimen matching changes in publichealthengland/ntbs-specimen-matching#5
* Run `uspPopulateCalendarTable` from `uspSeed` (but only do this during its first run)
* Run code based on `PopulateFeatureFlags.sql` script during initial DB setup from `uspSeed`
* Remove `PopulateFeatureFlags.sql` because it has been inlined into `uspSeed`

This means the entire DB can be set up just by running `uspGenerate`.

### Testing
Tested both acceptance criteria on local DBs: that the calendar table and feature flags are not modified if there already exists records in those tables, and that I can create a new reporting DB and it successfully runs `uspGenerate`, populating the calendar and feature flag tables.