### PR TITLE
NTBS-1824: Take account of migrated records and update date on migration reports

### DIFF
--- a/source/dbo/Stored Procedures/Data Migration/uspConfirmationLineList.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspConfirmationLineList.sql
@@ -24,9 +24,9 @@ AS
 		AND p.PHEC_Name = @Region
 		AND ny.Id >= -3
 		AND NOT EXISTS
-			(SELECT LegacyId
-			FROM [$(migration)].[dbo].ImportedNotifications impn
-			WHERE LegacyId = EtsId OR LegacyId = LtbrId)),
+			(SELECT NotificationId
+			FROM [$(NTBS)].[dbo].Notification ntbsn
+			WHERE ntbsn.ETSID = mn.EtsID OR ntbsn.LTBRID = mn.LtbrID)),
 	LinkedNotifications AS
 	(SELECT ng.GroupId, STRING_AGG(CAST(mn.PrimaryNotificationId AS NVARCHAR(MAX)), ', ') AS LinkedNotifications
 	FROM [$(migration)].[dbo].[MergedNotifications] mn 
@@ -61,9 +61,9 @@ AS
 	OR 
 		(p.PHEC_Name = @Region AND ny.Id >= -3)
 	AND NOT EXISTS
-		(SELECT LegacyId
-		FROM [$(migration)].[dbo].ImportedNotifications impn
-		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
+		(SELECT NotificationId
+		FROM [$(NTBS)].[dbo].Notification ntbsn
+		WHERE ntbsn.ETSID = mn.EtsID OR ntbsn.LTBRID = mn.LtbrID)
 
 	ORDER BY mn.NotificationDate DESC
 	

--- a/source/dbo/Stored Procedures/Data Migration/uspConfirmationLineList.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspConfirmationLineList.sql
@@ -22,7 +22,11 @@ AS
 	WHERE 
 		mn.GroupId IS NOT NULL
 		AND p.PHEC_Name = @Region
-		AND ny.Id >= -3),
+		AND ny.Id >= -3
+		AND NOT EXISTS
+			(SELECT LegacyId
+			FROM [$(migration)].[dbo].ImportedNotifications impn
+			WHERE LegacyId = EtsId OR LegacyId = LtbrId)),
 	LinkedNotifications AS
 	(SELECT ng.GroupId, STRING_AGG(CAST(mn.PrimaryNotificationId AS NVARCHAR(MAX)), ', ') AS LinkedNotifications
 	FROM [$(migration)].[dbo].[MergedNotifications] mn 

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
@@ -29,9 +29,9 @@ AS
 	WHERE mn.GroupId IS NOT NULL
 	AND p.PHEC_Name != @Region
 	AND NOT EXISTS
-		(SELECT LegacyId
-		FROM [$(migration)].[dbo].ImportedNotifications impn
-		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
+		(SELECT NotificationId
+		FROM [$(NTBS)].[dbo].Notification ntbsn
+		WHERE ntbsn.ETSID = mn.EtsID OR ntbsn.LTBRID = mn.LtbrID)
 	GROUP BY DATEPART(YEAR, NotificationDate), p.PHEC_Name
 	ORDER BY DATEPART(YEAR, NotificationDate), p.PHEC_Name DESC 
 RETURN 0

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
@@ -18,7 +18,11 @@ AS
 	WHERE 
 	mn.GroupId IS NOT NULL
 	AND p.PHEC_Name = @Region
-	AND ny.Id >= -3)
+	AND ny.Id >= -3
+	AND NOT EXISTS
+		(SELECT LegacyId
+		FROM [$(migration)].[dbo].ImportedNotifications impn
+		WHERE LegacyId = EtsId OR LegacyId = LtbrId))
 
 	SELECT DATEPART(YEAR, NotificationDate) AS 'NotificationYear', p.PHEC_Name AS Region, COUNT(PrimaryNotificationId) AS CountOfRecords  
 	FROM [$(migration)].[dbo].[MergedNotifications] mn 

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
@@ -4,7 +4,7 @@ AS
 
 
 	--we want to display a list of the additional notifications which will be migrated as part of a particular region's migration.
-	--these are records linked to the selected notifications, which may be outside the chosen the region
+	--these are records linked to the selected notifications, which may be outside the chosen the region OR outside the time period
 
 
 	--first find the groups
@@ -25,9 +25,11 @@ AS
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_Hospital] tbh ON tbh.HospitalID = mn.NtbsHospitalId
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_PHEC] tbsp ON tbsp.TB_Service_Code = tbh.TB_Service_Code
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p ON p.PHEC_Code = tbsp.PHEC_Code
+		LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
 		INNER JOIN NotificationGroups ng ON ng.GroupId = mn.GroupId
 	WHERE mn.GroupId IS NOT NULL
-	AND p.PHEC_Name != @Region
+	AND
+	(p.PHEC_Name != @Region OR ny.Id < -3 OR ny.Id IS NULL)
 	AND NOT EXISTS
 		(SELECT NotificationId
 		FROM [$(NTBS)].[dbo].Notification ntbsn

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
@@ -14,21 +14,27 @@ AS
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_Hospital] tbh ON tbh.HospitalID = mn.NtbsHospitalId
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_PHEC] tbsp ON tbsp.TB_Service_Code = tbh.TB_Service_Code
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p ON p.PHEC_Code = tbsp.PHEC_Code
+		LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
 	WHERE 
 	mn.GroupId IS NOT NULL
 	AND p.PHEC_Name = @Region
-	AND mn.NotificationDate >= '2017-01-01')
+	AND ny.Id >= -3)
 
 	SELECT DATEPART(YEAR, NotificationDate) AS 'NotificationYear', p.PHEC_Name AS Region, COUNT(PrimaryNotificationId) AS CountOfRecords  
 	FROM [$(migration)].[dbo].[MergedNotifications] mn 
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_Hospital] tbh ON tbh.HospitalID = mn.NtbsHospitalId
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_PHEC] tbsp ON tbsp.TB_Service_Code = tbh.TB_Service_Code
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p ON p.PHEC_Code = tbsp.PHEC_Code
+		LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
 		INNER JOIN NotificationGroups ng ON ng.GroupId = mn.GroupId
 	WHERE mn.GroupId IS NOT NULL
 	AND 
 	(p.PHEC_Name != @Region
-	OR mn.NotificationDate < '2017-01-01')
+	OR ny.Id >= -3)
+	AND NOT EXISTS
+		(SELECT LegacyId
+		FROM [$(migration)].[dbo].ImportedNotifications impn
+		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
 	GROUP BY DATEPART(YEAR, NotificationDate), p.PHEC_Name
 	ORDER BY DATEPART(YEAR, NotificationDate), p.PHEC_Name DESC 
 RETURN 0

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationAdditionalNotificationsByRegionAndYear.sql
@@ -18,23 +18,16 @@ AS
 	WHERE 
 	mn.GroupId IS NOT NULL
 	AND p.PHEC_Name = @Region
-	AND ny.Id >= -3
-	AND NOT EXISTS
-		(SELECT LegacyId
-		FROM [$(migration)].[dbo].ImportedNotifications impn
-		WHERE LegacyId = EtsId OR LegacyId = LtbrId))
+	AND ny.Id >= -3)
 
 	SELECT DATEPART(YEAR, NotificationDate) AS 'NotificationYear', p.PHEC_Name AS Region, COUNT(PrimaryNotificationId) AS CountOfRecords  
 	FROM [$(migration)].[dbo].[MergedNotifications] mn 
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_Hospital] tbh ON tbh.HospitalID = mn.NtbsHospitalId
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_PHEC] tbsp ON tbsp.TB_Service_Code = tbh.TB_Service_Code
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p ON p.PHEC_Code = tbsp.PHEC_Code
-		LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
 		INNER JOIN NotificationGroups ng ON ng.GroupId = mn.GroupId
 	WHERE mn.GroupId IS NOT NULL
-	AND 
-	(p.PHEC_Name != @Region
-	OR ny.Id >= -3)
+	AND p.PHEC_Name != @Region
 	AND NOT EXISTS
 		(SELECT LegacyId
 		FROM [$(migration)].[dbo].ImportedNotifications impn

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationLineList.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationLineList.sql
@@ -20,7 +20,12 @@ AS
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_Hospital] tbh ON tbh.HospitalID = mn.NtbsHospitalId
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_PHEC] tbsp ON tbsp.TB_Service_Code = tbh.TB_Service_Code
 		LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p ON p.PHEC_Code = tbsp.PHEC_Code
+		LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
 	WHERE 
 	(p.PHEC_Name = @Region
-	AND mn.NotificationDate >= '2017-01-01')
+	AND ny.Id >= -3)
+	AND NOT EXISTS
+		(SELECT LegacyId
+		FROM [$(migration)].[dbo].ImportedNotifications impn
+		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
 RETURN 0

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationLineList.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationLineList.sql
@@ -25,7 +25,7 @@ AS
 	(p.PHEC_Name = @Region
 	AND ny.Id >= -3)
 	AND NOT EXISTS
-		(SELECT LegacyId
-		FROM [$(migration)].[dbo].ImportedNotifications impn
-		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
+		(SELECT NotificationId
+		FROM [$(NTBS)].[dbo].Notification ntbsn
+		WHERE ntbsn.ETSID = mn.EtsID OR ntbsn.LTBRID = mn.LtbrID)
 RETURN 0

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationSelectedNotificationsByYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationSelectedNotificationsByYear.sql
@@ -9,9 +9,9 @@ AS
 	LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
 	WHERE p.PHEC_Name = @Region AND ny.Id >= -3
 	AND NOT EXISTS
-		(SELECT LegacyId
-		FROM [$(migration)].[dbo].ImportedNotifications impn
-		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
+		(SELECT NotificationId
+		FROM [$(NTBS)].[dbo].Notification ntbsn
+		WHERE ntbsn.ETSID = mn.EtsID OR ntbsn.LTBRID = mn.LtbrID)
 	GROUP BY DATEPART(YEAR, NotificationDate)
 	ORDER BY DATEPART(YEAR, NotificationDate) DESC 
 RETURN 0

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationSelectedNotificationsByYear.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationSelectedNotificationsByYear.sql
@@ -6,7 +6,12 @@ AS
 	LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_Hospital] tbh ON tbh.HospitalID = mn.NtbsHospitalId
 	LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[TB_Service_to_PHEC] tbsp ON tbsp.TB_Service_Code = tbh.TB_Service_Code
 	LEFT OUTER JOIN  [$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p ON p.PHEC_Code = tbsp.PHEC_Code
-	WHERE p.PHEC_Name = @Region AND mn.NotificationDate >= '2017-01-01'
+	LEFT JOIN vwNotificationYear ny ON ny.NotificationYear = YEAR(mn.NotificationDate)
+	WHERE p.PHEC_Name = @Region AND ny.Id >= -3
+	AND NOT EXISTS
+		(SELECT LegacyId
+		FROM [$(migration)].[dbo].ImportedNotifications impn
+		WHERE LegacyId = EtsId OR LegacyId = LtbrId)
 	GROUP BY DATEPART(YEAR, NotificationDate)
 	ORDER BY DATEPART(YEAR, NotificationDate) DESC 
 RETURN 0


### PR DESCRIPTION
Now only take records from the last 3 full years and also exclude any records that are already migrated into NTBS.