### PR TITLE
NTBS-2254: streamline user permissions view so it only contains user …

### DIFF
--- a/source/dbo/Views/Authorization/vwUserPermissions.sql
+++ b/source/dbo/Views/Authorization/vwUserPermissions.sql
@@ -1,13 +1,16 @@
-﻿CREATE VIEW [dbo].[vwUserPermissions]
+﻿--this produces a list of codes (TB service, PHEC) that the user is associated with
+--by way of their AD group membership. It excludes the national team (NTS) and the Admin group
+--as the national team can view all records and the Admin group is not about record access
+
+CREATE VIEW [dbo].[vwUserPermissions]
 	AS 
 	--create one row for each AD group the user is a member of
-	SELECT Username AS upn, COALESCE(t.Code, p.Code, A.[value]) AS 'Code', COALESCE(t.[Name], p.[Name]) AS 'Name',  COALESCE(p.[Code], tbsphec.[Code]) AS 'RegionCode' 
+	SELECT Username AS upn, COALESCE(t.Code, p.Code, A.[value]) AS 'Code'
 	FROM [$(NTBS)].[dbo].[User]
 
 		CROSS APPLY STRING_SPLIT(AdGroups, ',') A
 		LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[TbService] t ON t.ServiceAdGroup = A.[value]
 		LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[PHEC] p ON p.AdGroup = A.[value]
-		LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[PHEC] tbsphec ON tbsphec.Code = t.PHECCode
 		WHERE 
 		A.[value] != 'Global.NIS.NTBS.Admin'
 		AND A.[value] != 'Global.NIS.NTBS.NTS'


### PR DESCRIPTION
…principal name and code

These are the only values needed for Power BI row-level security