### PR TITLE
NTBS-2302 Add disease site list to Record_CaseData

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateEtsCaseRecord.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateEtsCaseRecord.sql
@@ -8,11 +8,13 @@ BEGIN TRY
 	);
 
 	INSERT INTO @TempDiseaseSites
-	SELECT TuberculosisEpisodeId, [Description] = STRING_AGG([Name], N', ')
-		FROM [$(ETS)].dbo.TuberculosisEpisodeDiseaseSite diseaseSite
+	SELECT n.TuberculosisEpisodeId, [Description] = STRING_AGG(sites.[Name], N', ')
+		FROM RecordRegister rr
+			INNER JOIN [$(ETS)].dbo.[Notification] n ON rr.NotificationId = n.LegacyId
+			INNER JOIN [$(ETS)].dbo.TuberculosisEpisodeDiseaseSite diseaseSite ON n.TuberculosisEpisodeId = diseaseSite.TuberculosisEpisodeId
 			INNER JOIN [$(ETS)].dbo.DiseaseSite sites ON sites.Id = diseaseSite.DiseaseSiteId
-		WHERE diseaseSite.AuditDelete IS NULL
-		GROUP BY TuberculosisEpisodeId;
+		WHERE rr.SourceSystem = 'ETS' AND diseaseSite.AuditDelete IS NULL
+		GROUP BY n.TuberculosisEpisodeId;
 
 	INSERT INTO [dbo].[Record_CaseData](
 		[NotificationId]

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
@@ -8,10 +8,12 @@ BEGIN TRY
 	);
 
 	INSERT INTO @TempDiseaseSites
-	SELECT NotificationId, [Description] = STRING_AGG([Description], N', ')
-		FROM [$(NTBS)].[dbo].[NotificationSite] notificationSite
-		JOIN [$(NTBS)].[ReferenceData].[Site] sites ON notificationSite.SiteId = sites.SiteId
-		GROUP BY NotificationId;
+	SELECT rr.NotificationId, [Description] = STRING_AGG([Description], N', ')
+		FROM RecordRegister rr
+			INNER JOIN [$(NTBS)].[dbo].[NotificationSite] notificationSite ON rr.NotificationId = notificationSite.NotificationId
+			INNER JOIN [$(NTBS)].[ReferenceData].[Site] sites ON notificationSite.SiteId = sites.SiteId
+		WHERE rr.SourceSystem = 'NTBS'
+		GROUP BY rr.NotificationId;
 
 	INSERT INTO [dbo].[Record_CaseData](
 		[NotificationId]

--- a/source/dbo/Tables/Power BI Reporting/Record_CaseData.sql
+++ b/source/dbo/Tables/Power BI Reporting/Record_CaseData.sql
@@ -1,5 +1,5 @@
 ﻿CREATE TABLE [dbo].[Record_CaseData](
-	
+
 	[CaseDataId] [int] IDENTITY(1,1) NOT NULL,
 
 	-- Global (ETS, LTBR, NTBS encompassing) primary key
@@ -7,7 +7,7 @@
 	[EtsId] [bigint] NULL,
 	[LtbrId] [varchar](20) NULL,
 	[LinkedNotifications] [varchar](200) NULL,
-	
+
 	[CaseManager] [nvarchar](101) NULL,
 	[Consultant] [nvarchar](255) NULL,
 	[HospitalId] [varchar](36) NULL,
@@ -44,6 +44,7 @@
 	[OnsetToTreatmentDays] INT NULL,
 	[HivTestOffered] [varchar](30) NULL,
 	[SiteOfDisease] [varchar](50) NULL,
+	[DiseaseSiteList] [varchar](2000) NULL,
 	[PostMortemDiagnosis] [varchar](10) NULL,
 	[StartedTreatment] [varchar](10) NULL,
 	[TreatmentRegimen] [nvarchar](30) NULL,
@@ -141,15 +142,15 @@
 	[BiologicalTherapy] [varchar](10)  NULL,
 	[Transplantation] [varchar](10)  NULL,
 	[OtherImmunoSuppression] [varchar](30) NULL,
-	
-	
-	
-	
+
+
+
+
 	[DataRefreshedAt] [datetime] NOT NULL
 
 	 CONSTRAINT [PK_CaseDataId] PRIMARY KEY CLUSTERED (
 		[CaseDataId] ASC
-	) 
+	)
 ) ON [PRIMARY]
 GO
 


### PR DESCRIPTION
### Description
Add a comma separated list of disease sites to `Record_Data.DiseaseSiteList`, a new field. This comes from NTBS and ETS
depending on the notification, and uses disease site names from the respective system.

This is based on how a similar field is calculated for `ForestExtract`. 

### Testing
Tested the insertion locally using the basic test data, and have tested the queries work on live data (just not the insertion bit). This code has not been deployed anywhere