### PR TITLE
NTBS-2259: Add default no result value for chest xray for all case record

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingCaseData.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingCaseData.sql
@@ -31,6 +31,7 @@ BEGIN TRY
 				WHEN TreatmentOutcome24months IS NOT NULL AND TreatmentOutcome24months != '' AND TreatmentOutcome24months != 'Error: invalid value' THEN TreatmentOutcome24months
 				WHEN TreatmentOutcome12months IS NOT NULL AND TreatmentOutcome12months != '' AND TreatmentOutcome12months != 'Error: invalid value' THEN TreatmentOutcome12months
 			END
+		,ChestXrayResult = COALESCE(ChestXRayResult, 'No result')
 	FROM [dbo].[Record_CaseData] cd
 		INNER JOIN [dbo].[Record_PersonalDetails] pd ON pd.NotificationId = cd.NotificationId
 		INNER JOIN [dbo].[RecordRegister] rr ON rr.NotificationId = cd.NotificationId

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspMapCaseRecordChestXrayResults.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspMapCaseRecordChestXrayResults.sql
@@ -17,7 +17,7 @@ BEGIN TRY
 	WHERE ManualTestTypeId = 4
 	)
 	UPDATE cd
-	SET ChestXRayResult = COALESCE(resultLookup.FormattedResult, 'No result')
+	SET ChestXRayResult = resultLookup.FormattedResult
 	FROM [dbo].[Record_CaseData] cd
 		LEFT OUTER JOIN rankedResults ON rankedResults.NotificationId = cd.NotificationId AND rankedResults.rn = 1
 		LEFT JOIN ChestXrayResultLookup resultLookup ON resultLookup.Result = rankedResults.result


### PR DESCRIPTION
Add the 'No result' value to ETS records chest xray result.