### PR TITLE
NTBS-2358 Use PHE UAT migration DB instead of live

### DIFF
--- a/source/Publish Profiles/DELETE/phe-ntbs-uat-reporting-DELETE.publish.xml
+++ b/source/Publish Profiles/DELETE/phe-ntbs-uat-reporting-DELETE.publish.xml
@@ -87,7 +87,7 @@
       <Value>NTBS_LondonTBR_Live</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="migration">
-      <Value>NTBS_Migration_Live</Value>
+      <Value>NTBS_Migration_UAT</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="NTBS">
       <Value>NTBS_UAT</Value>

--- a/source/Publish Profiles/Pre-production/phe-ntbs-uat-reporting.publish.xml
+++ b/source/Publish Profiles/Pre-production/phe-ntbs-uat-reporting.publish.xml
@@ -23,7 +23,7 @@
       <Value>NTBS_LondonTBR_Live</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="migration">
-      <Value>NTBS_Migration_Live</Value>
+      <Value>NTBS_Migration_UAT</Value>
     </SqlCmdVariable>
     <SqlCmdVariable Include="NTBS">
       <Value>NTBS_UAT</Value>


### PR DESCRIPTION
Use the PHE UAT migration DB that has recently been created instead of the live one for UAT reporting,

This has not been deployed anywhere