### PR TITLE
NTBS-2355 Fix records without X-rays getting ignored

### DIFF
--- a/source/dbo/Stored Procedures/Extracts/uspPopulateForestExtract.sql
+++ b/source/dbo/Stored Procedures/Extracts/uspPopulateForestExtract.sql
@@ -168,7 +168,7 @@ BEGIN
 		LEFT JOIN [$(NTBS_R1_Geography_Staging)].[dbo].[Reduced_Postcode_file] pl ON pl.Pcode = patient.PostcodeToLookup
 		LEFT JOIN [$(ETS)].[dbo].[NACS_pctlookup] nacs ON nacs.PCT_code = pl.PctCode
 		LEFT JOIN @TempDiseaseSites diseaseSites ON diseaseSites.NotificationId = patient.NotificationId
-		CROSS APPLY [dbo].[ufnGetCaseRecordChestXrayResults](n.NotificationId, clinicalDetails.DiagnosisDate) ChestXRayResult
+		OUTER APPLY [dbo].[ufnGetCaseRecordChestXrayResults](n.NotificationId, clinicalDetails.DiagnosisDate) ChestXRayResult
 		WHERE nsm.MatchType = 'Confirmed'
 			AND (servicePhec.Name IN ('North East', 'North West', 'Yorkshire and Humber', 'West Midlands',
 										'East Midlands', 'East of England', 'London', 'South East', 'South West'));

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
@@ -315,7 +315,7 @@ BEGIN TRY
 		LEFT OUTER JOIN [dbo].[TreatmentRegimenLookup] trl ON trl.TreatmentRegimenCode = cd.TreatmentRegimen
 		LEFT OUTER JOIN [dbo].[DOTLookup] dl ON dl.SystemValue = cd.DotStatus
 		LEFT OUTER JOIN @TempDiseaseSites diseaseSites ON diseaseSites.NotificationId = n.NotificationId
-		CROSS APPLY [dbo].[ufnGetCaseRecordChestXrayResults](rr.NotificationId, cd.DiagnosisDate) ChestXRayResult
+		OUTER APPLY [dbo].[ufnGetCaseRecordChestXrayResults](rr.NotificationId, cd.DiagnosisDate) ChestXRayResult
 	WHERE rr.SourceSystem = 'NTBS'
 
 	--'Sample taken' should be set if there are any manually-entered test results which are NOT of type chest x-ray


### PR DESCRIPTION
### Description
Fix records without chest x-rays getting missed by the Record_CaseData
and ForestExtract generating procedures.

This was an issue because ufnGetCaseRecordChestXrayResults returns
nothing if the notification doesn't have a chest X-Ray, so the
notification gets discarded by a cross apply, but not an outer apply.

### Testing
Tested (more thoroughly this time!) on local data. This has not been deployed anywhere