### PR TITLE
NTBS-2389 Keep Record_PersonalDetails.Postcode when invalid

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingRecords.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingRecords.sql
@@ -102,7 +102,7 @@ BEGIN TRY
 		,p.FamilyName										AS Surname
 		,CONVERT(DATE, p.Dob)								AS DateOfBirth
 		,p.PostcodeToLookup									AS PostcodeToLookup
-		,p.PostcodeToLookup									AS Postcode --this will later be reformatted if valid
+		,p.Postcode											AS Postcode --this will replaced with a reformatted PostcodeToLookup if valid
 	FROM
 		[dbo].[RecordRegister] rr
 		INNER JOIN [$(NTBS)].[dbo].[Patients] p ON p.NotificationId = rr.NotificationId

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspUpdateRecordPostcode.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspUpdateRecordPostcode.sql
@@ -1,42 +1,42 @@
 ﻿/*
 	This procedure creates a cleaned postcode from the value supplied from the notification system (ETS or NTBS)
 	Provided the postcode matches the format and length of a UK postcode, this will insert a single space 3 characters from
-	the right hand side of the string
+	the right hand side of the string. Otherwise, it will leave the postcode value unchanged
 */
 
 CREATE PROCEDURE [dbo].[uspUpdateRecordPostcode] AS
 	SET NOCOUNT ON
 
 	BEGIN TRY
-		
 
-		IF object_id('tempdb.dbo.#RecordPostcodes','U') IS NOT NULL 
-		BEGIN	
+
+		IF object_id('tempdb.dbo.#RecordPostcodes','U') IS NOT NULL
+		BEGIN
 			DROP TABLE #RecordPostcodes
 		END
 
-		SELECT DISTINCT 
+		SELECT DISTINCT
 			PersonalDetailsId
-			,REPLACE(PostcodeToLookup, ' ', '')	AS CleanedPostcode
+			,PostcodeToLookup AS CleanedPostcode
 		INTO #RecordPostcodes
 		FROM [dbo].[Record_PersonalDetails]
-  
-		DELETE from #RecordPostcodes 
-		WHERE LEN(CleanedPostcode)<5 OR LEN(CleanedPostcode) > 7 OR CleanedPostcode NOT LIKE '%[^0-9]%'
+		WHERE PostcodeToLookup IS NOT NULL
+			AND LEN(PostcodeToLookup) >= 5
+			AND LEN(PostcodeToLookup) <= 7
+			AND PostcodeToLookup LIKE '%[^0-9]%'
 
 
 		UPDATE #RecordPostcodes
-			SET CleanedPostcode = SUBSTRING(CleanedPostcode, 1, LEN(CleanedPostcode)-3) + ' ' + RIGHT(CleanedPostcode,3)
-  
+			SET CleanedPostcode = SUBSTRING(CleanedPostcode, 1, LEN(CleanedPostcode)-3) + ' ' + RIGHT(CleanedPostcode, 3)
+
 		UPDATE r
-		SET 
+		SET
 			Postcode = n.CleanedPostcode
 		FROM [Record_PersonalDetails] r
-		INNER JOIN #RecordPostcodes n ON n.PersonalDetailsId = r.PersonalDetailsId
+			INNER JOIN #RecordPostcodes n ON n.PersonalDetailsId = r.PersonalDetailsId
 
-  	END TRY
+	END TRY
 	BEGIN CATCH
 		THROW
 	END CATCH
 GO
-


### PR DESCRIPTION
## Description
When populating `Record_PersonalDetails.Postcode`, first set this to the NTBS `Patients.Postcode`. This is what the user entered, and may be invalid, and may not be formatted correctly.

Replace `Record_PersonalDetails.Postcode` with a formatted version of `Patients.PostcodeToLookup`, if it exists and is valid. If it doesn't exist or is invalid, leave `Record_PersonalDetails.Postcode` as what the user originally entered.

## Testing
Tested locally with an amended version of ETS to have BPFO postcodes. This has not been deployed anywhere