### PR TITLE
NTBS-2414 Add other disease site text to legacy extract

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingLegacySitesOfDisease.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingLegacySitesOfDisease.sql
@@ -12,34 +12,34 @@ BEGIN TRY
 	FROM [dbo].[RecordRegister]
 	WHERE SourceSystem = 'NTBS'),
 
-	--then one row per legacy site for the notification. This will group 
+	--then one row per legacy site for the notification. This will group
 	--some sites together under 'NonPulmonaryOther'
 		cteNotificationSites (NotificationId, SiteOutputName, HasSite) AS
-		(SELECT ns.NotificationId, ls.SiteOutputName, 'TRUE' AS 'HasSite' 
+		(SELECT ns.NotificationId, ls.SiteOutputName, 'TRUE' AS 'HasSite'
 		FROM [$(NTBS)].[dbo].[NotificationSite] ns
 		INNER JOIN cteNotification ce ON ce.NotificationId = ns.NotificationId
 		LEFT OUTER JOIN [dbo].[LegacySiteMapping] ls ON ls.SiteId = ns.SiteId
 		GROUP BY ns.NotificationId, ls.SiteOutputName),
-		
+
 	--then cross-join so there is one per notification and site of disease, inserting a zero if the notification does not have that site of disease
 	--also map to output names
 
 	cteAllResults(NotificationId, SiteOutputName, HasSite) AS
 	(SELECT DISTINCT n.NotificationId, cd.SiteOutputName, COALESCE(c.HasSite, 'FALSE') AS HasSite
-		FROM cteNotification n 
+		FROM cteNotification n
 		CROSS JOIN cteLegacyDiseaseSites cd
 		LEFT OUTER JOIN cteNotificationSites c
 			ON c.NotificationId = n.NotificationId AND c.SiteOutputName = cd.SiteOutputName),
 
 	--then create a pivot table of the values so there is one row per notificationId
-	ctePivotResults(NotificationId, [SitePulmonary], [SiteBoneSpine], [SiteBoneOther], [SiteCNSMeningitis], [SiteCNSOther], [SiteCryptic], [SiteGI], [SiteGU], [SiteITLymphNodes], 
+	ctePivotResults(NotificationId, [SitePulmonary], [SiteBoneSpine], [SiteBoneOther], [SiteCNSMeningitis], [SiteCNSOther], [SiteCryptic], [SiteGI], [SiteGU], [SiteITLymphNodes],
 				[SiteLymphNode], [SiteLaryngeal], [SiteMiliary], [SitePleural], [SiteNonPulmonaryOther]) AS
 	(SELECT * FROM cteAllResults
 		AS SOURCE
 		PIVOT
 		(
 			MAX(HasSite)
-			FOR [SiteOutputName] IN ([SitePulmonary], [SiteBoneSpine], [SiteBoneOther], [SiteCNSMeningitis], [SiteCNSOther], [SiteCryptic], [SiteGI], [SiteGU], [SiteITLymphNodes], 
+			FOR [SiteOutputName] IN ([SitePulmonary], [SiteBoneSpine], [SiteBoneOther], [SiteCNSMeningitis], [SiteCNSOther], [SiteCryptic], [SiteGI], [SiteGU], [SiteITLymphNodes],
 				[SiteLymphNode], [SiteLaryngeal], [SiteMiliary], [SitePleural], [SiteNonPulmonaryOther])
 		) AS Result)
 
@@ -63,6 +63,17 @@ BEGIN TRY
 		SiteUnknown = 'FALSE'
 		FROM [dbo].[Record_LegacyExtract] le
 			INNER JOIN ctePivotResults pr ON pr.NotificationId = le.NotificationId
+
+	--Add in the OtherExtraPulmonarySite text
+	UPDATE le
+		SET OtherExtraPulmonarySite = Descriptions.SiteDescription
+	FROM [dbo].[Record_LegacyExtract] le
+		INNER JOIN (
+			SELECT NotificationId,
+					SiteDescription
+				FROM [$(NTBS)].[dbo].[NotificationSite]
+				WHERE SiteId = 17
+		) AS Descriptions ON Descriptions.NotificationId = le.NotificationId
 
 END TRY
 BEGIN CATCH


### PR DESCRIPTION
### Description
Add the `SiteDescription` text stored for 'other' disease sites in NTBS to the legacy extract.

### Testing
Tested locally using ETS test data. This change has not been deployed anywhere yet.