### PR TITLE
NTBS-2432: No Sample taken

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingLegacyExtract.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingLegacyExtract.sql
@@ -32,6 +32,7 @@ BEGIN TRY
         ,[HospitalLocalAuthority]
         ,[ResolvedResidenceRegion]
         ,[ResolvedResidenceLA]
+		,[NoSampleTaken]
         ,[WorldRegionName])
 
 		SELECT
@@ -58,7 +59,11 @@ BEGIN TRY
 			,la.[Name]																	AS HospitalLocalAuthority
 			,cd.ResidencePhec															AS ResolvedResidenceRegion 
 			,pl.LTLA_Name																AS ResolvedResidenceLA
-			,continent.[Name]															AS WorldRegionName
+			,CASE cd.SampleTaken
+				WHEN 'Yes' THEN 0
+				ELSE 1
+			END																			AS NoSampleTaken
+			,COALESCE(continent.[Name], 'Unknown')										AS WorldRegionName
 		FROM
 			[dbo].[RecordRegister] rr
 				INNER JOIN [dbo].[Record_CaseData] cd ON cd.NotificationId = rr.NotificationId


### PR DESCRIPTION
In our general reporting world, we have a field called 'Sample Taken' rather than the value which has always been used historically, 'No Sample Taken'. For the Legacy Extract, we thus need to create a reverse value.

We also noted during testing that if World Region is empty, the Legacy Extract outputs 'Unknown' in ETS so have reproduced that as well.