### PR TITLE
Removed hard-coded Migration Run ID

### DIFF
--- a/source/dbo/Stored Procedures/Data Migration/uspGenerateMigrationResultsData.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspGenerateMigrationResultsData.sql
@@ -207,7 +207,7 @@ BEGIN TRY
 				END) AS								[Message] 
 	
 			FROM [$(NTBS)].[dbo].[LegacyImportNotificationLogMessage]
-			WHERE LegacyImportMigrationRunId = 6 
+			WHERE LegacyImportMigrationRunId = @MigrationRunID
 			AND [Message] NOT LIKE 'has % validation errors'
 			AND [Message] != 'User set as case manager for notification is not a case manager.') AS Q1 
 				ON Q1.OldNotificationId = li.OldNotificationId AND Q1.LegacyImportMigrationRunId = li.LegacyImportMigrationRunId


### PR DESCRIPTION
Migration run ID of 6 had been left in the code, should be variable @MigrationRunID