### PR TITLE
Update to logic which looks for the migration job to process from NTBS

### DIFF
--- a/source/dbo/Stored Procedures/Data Migration/uspGenerateMigrationResultsData.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspGenerateMigrationResultsData.sql
@@ -17,7 +17,7 @@ BEGIN TRY
 	SET @MigrationRunID = (SELECT MAX(lmr.LegacyImportMigrationRunId) AS MigrationRunId
 	FROM
 	[$(NTBS)].[dbo].[LegacyImportMigrationRun] lmr 
-	WHERE lmr.LegacyImportMigrationRunId > (SELECT COALESCE(MAX(MigrationRunId), 1) FROM [dbo].[MigrationRun] WHERE ImportedDate IS NOT NULL))
+	WHERE lmr.LegacyImportMigrationRunId > (SELECT COALESCE(MAX(MigrationRunId), 0) FROM [dbo].[MigrationRun] WHERE ImportedDate IS NOT NULL))
 
 	
 	INSERT INTO [dbo].[MigrationRun](MigrationRunId, MigrationRunDate, MigrationRunName, AppVersion)


### PR DESCRIPTION
This did not work when we first ran it in live, because it first looks at its own table, MigrationRun, to see what is the last job number it processed. If it doesn't find one (as it would not on first execution in an environment) it looks for one with a value greater than 1. It should be zero; the first migration run has the number 1.