### PR TITLE
NTBS-2547: Bug fix

### DIFF
--- a/source/dbo/Stored Procedures/Lab Results/uspSummarisedNTBSMatches.sql
+++ b/source/dbo/Stored Procedures/Lab Results/uspSummarisedNTBSMatches.sql
@@ -11,7 +11,7 @@ AS
 		SUM(CASE WHEN MatchType = 'Possible' THEN 1 ELSE 0 END) AS 'NumberOfPotentialMatches',
 		SUM(CASE WHEN MatchType = 'Rejected' THEN 1 ELSE 0 END) AS 'NumberOfRejectedMatches'
 	FROM [$(NTBS_Specimen_Matching)].[dbo].[NotificationSpecimenMatch] 
-	WHERE  MatchMethod != 'Migration'
+	WHERE  (MatchMethod != 'Migration' or MatchMethod is null)
 		AND UpdateDateTime >= @StartDate
 	GROUP BY DATEPART(YEAR, UpdateDateTime)
 RETURN 0


### PR DESCRIPTION
The possible matches were not being included in the count, because their matchmethod is NULL so were excluded by the WHERE clause