### PR TITLE
NTBS-2574: remove build warnings

### DIFF
--- a/source/dbo/Views/Power BI Reporting/vwCaseManagerIssuesReport.sql
+++ b/source/dbo/Views/Power BI Reporting/vwCaseManagerIssuesReport.sql
@@ -19,7 +19,7 @@ WITH PermissionAliases(ETSName, AliasName) AS (
 
 --get the permissions, map HPU up to Region and remove the first and last characters as these are (except for HPA) always square brackets
 ETSPermissions AS (
-	SELECT s.id,
+	SELECT s.Id,
 		LOWER(s.Username) AS Username,
 		LOWER(s.Email) AS Email,
 		[dbo].[ufnStripNonAlphaChars](s.Surname) AS Surname,
@@ -41,7 +41,7 @@ ETSPermissions AS (
 ),
 --overwrite the permission name
 AliasedPermissions AS (
-	SELECT ep.id,
+	SELECT ep.Id,
 		ep.Username,
 		ep.Email,
 		ep.Surname,
@@ -89,7 +89,7 @@ SELECT n.NotificationId,
 	EtsUserDetails.Membership AS EtsUserPermissionMembership,
 	EtsUserDetails.TBServicePHEC AS EtsUserPermissionTbServicePhec,
 	EtsUserDetails.MembershipCode AS EtsUserPermissionMembershipCode,
-	EtsUserDetails.id AS EtsUserId
+	EtsUserDetails.Id AS EtsUserId
 FROM [$(NTBS)].dbo.[Notification] n
 	INNER JOIN [$(NTBS)].dbo.HospitalDetails hd ON n.NotificationId = hd.NotificationId
 	INNER JOIN [$(NTBS)].dbo.[User] u ON hd.CaseManagerId = u.Id

--- a/source/dbo/Views/Power BI Reporting/vwRegionAndPermissions.sql
+++ b/source/dbo/Views/Power BI Reporting/vwRegionAndPermissions.sql
@@ -10,9 +10,9 @@ CREATE VIEW [dbo].[vwRegionAndPermissions]
 	AS 
 	WITH RegionsAndPermissions AS
 (
-	SELECT p.Phec_Code, p.Phec_Name, Q1.Id
+	SELECT p.PHEC_Code, p.PHEC_Name, Q1.Id
 	FROM 
-	[$(NTBS_R1_Geography_Staging)].[dbo].[Phec] p
+	[$(NTBS_R1_Geography_Staging)].[dbo].[PHEC] p
 		INNER JOIN  
 		(
 			SELECT * 
@@ -21,7 +21,7 @@ CREATE VIEW [dbo].[vwRegionAndPermissions]
 		) 
 		--very ugly join on name of region being in name of permission, limited to only first 8 characters
 		--because the region is called Yorkshire and Humber but the permission is called Yorkshire and the Humber
-		AS Q1 ON CHARINDEX(LEFT(p.Phec_Name, 8), Q1.[NAME]) > 0
+		AS Q1 ON CHARINDEX(LEFT(p.PHEC_Name, 8), Q1.[NAME]) > 0
 ),
 
 PermissionHierarchy AS


### PR DESCRIPTION
Changed case on field names as the build warnings create noise during the release process