### PR TITLE
NTBS-2588 incorrect date appears in report footer for NTBS

### DIFF
--- a/source/dbo/Stored Procedures/Reusable Footer/uspGenerateFooter.sql
+++ b/source/dbo/Stored Procedures/Reusable Footer/uspGenerateFooter.sql
@@ -24,7 +24,7 @@ CREATE PROCEDURE [dbo].[uspGenerateFooter] AS
 		SET @NtbsLastRefreshed = (SELECT MAX([AuditDateTime])
 			FROM [$(NTBS_AUDIT)].[dbo].[AuditLogs]
 			WHERE AuditDateTime > DATEADD(DAY, -7, GETUTCDATE())
-				AND EntityType = 'Notification'
+				AND RootEntity = 'Notification'
 				AND EventType != 'Read')
 		
 		-- When were the generated reusable tables last refreshed ?


### PR DESCRIPTION
The code had not been updated after the audit database was restructured, so it was looking in the 'EntityType' column for the value 'Notification' when it should be looking in the 'RootEntity' column.  This is having a minor effect in live, depending on what kind of updates are performed the day before.