### PR TITLE
NTBS-2659: Fix migration report stored procs

### DIFF
--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationDuplicateAlerts.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationDuplicateAlerts.sql
@@ -43,7 +43,7 @@ AS
 			ELSE 'No'
 		END																			AS 'DemographicsMatch'
 	FROM DuplicatePairs pairs
-		LEFT JOIN [dbo].[MigrationRunResults] mrr ON mrr.NTBSNotificationId = pairs.FirstNotification
+		LEFT JOIN [dbo].[MigrationRunResults] mrr ON mrr.NTBSNotificationId = pairs.FirstNotification AND mrr.MigrationRunId = @MigrationRun
 		LEFT JOIN [$(NTBS)].[dbo].[Notification] firstNot on firstNot.NotificationId = pairs.FirstNotification
 		LEFT JOIN [$(NTBS)].[dbo].[Patients] firstNotP on firstNotP.NotificationId = firstNot.NotificationId
 		LEFT JOIN [$(NTBS)].[dbo].[HospitalDetails] firstNotHd on firstNotHd.NotificationId = firstNot.NotificationId

--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationSpecimenMatchesToReviewBySpecimen.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationSpecimenMatchesToReviewBySpecimen.sql
@@ -24,7 +24,7 @@ AS
 		dbo.ufnGetTreatmentEndDate(ntbsn.NotificationId)		AS 'TreatmentEndDate',
 		mdsm.MigrationNotes										AS 'MigrationNotes'
 	FROM [dbo].[MigrationDubiousSpecimenMatches] mdsm
-		LEFT JOIN [dbo].[MigrationRunResults] mrr ON mdsm.EtsId = mrr.LegacyETSId
+		LEFT JOIN [dbo].[MigrationRunResults] mrr ON mdsm.EtsId = mrr.LegacyETSId AND mrr.MigrationRunId = @MigrationRun
 		LEFT JOIN [$(ETS)].[dbo].[Notification] etsn ON etsn.LegacyId = mdsm.EtsId
 		LEFT JOIN [$(NTBS)].[dbo].[Notification] ntbsn ON ntbsn.ETSID = mdsm.EtsId
 		INNER JOIN [$(NTBS_Specimen_Matching)].[dbo].[EtsSpecimenMatch] esm ON esm.LegacyId = mdsm.EtsId AND esm.ReferenceLaboratoryNumber = mdsm.ReferenceLaboratoryNumber


### PR DESCRIPTION
I hadn't thought about the fact that MigrationRunResults will have all the old runs in, so was joining all cases of a notification. Now join on the MigrationRunId also. 