### PR TITLE
NTBS-2700: summarise results of sputum testing

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingCaseData.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingCaseData.sql
@@ -8,6 +8,8 @@ BEGIN TRY
 	
 	--finally do stuff that makes sense just to do for all records, like the last recorded treatment outcome 
 
+	EXEC [dbo].[uspGenerateSputumResult]
+
 	UPDATE cd 
 	SET AnySocialRiskFactor = CASE 
 		WHEN AlcoholMisuse = 'Yes' 

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateSputumResult.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateSputumResult.sql
@@ -1,0 +1,73 @@
+﻿/*Summarise the sputum results for each case, across all test types
+TODO: this may exclude culture
+If the case has both positive and negative results, display positive.
+If the case has no results, or only awaiting/unknown values display 'Unknown' */
+
+
+
+CREATE PROCEDURE [dbo].[uspGenerateSputumResult]
+	
+AS
+	WITH
+
+	ResultRanking AS
+	(
+
+		SELECT 1 AS [Rank], 'Positive' AS ResultName
+		UNION
+		SELECT 2 AS [Rank], 'Negative' AS ResultName
+		UNION
+		SELECT 3 AS [Rank], 'Awaiting' AS ResultName
+		UNION
+		SELECT 4 AS [Rank], 'Not known' AS ResultName
+	),
+
+	EtsSputumResults AS
+	(
+		SELECT DISTINCT rr.NotificationId, rr.SourceSystem, FIRST_VALUE(lrc.[Name]) OVER (PARTITION BY rr.NotificationId ORDER BY rra.[Rank]) AS ResultName
+		FROM
+			[$(ETS)].[dbo].[Notification] n
+				INNER JOIN [dbo].[RecordRegister] rr ON rr.NotificationId = n.LegacyId AND rr.SourceSystem = 'ETS'
+				INNER JOIN [$(ETS)].[dbo].[LaboratoryResult] lr ON lr.NotificationId = n.Id
+				INNER JOIN [$(ETS)].[dbo].[LaboratoryResultCode] lrc ON lrc.LegacyId = lr.Result
+				INNER JOIN ResultRanking rra ON rra.ResultName = lrc.[Name]
+			WHERE lr.OpieId IS NULL AND lr.AuditDelete IS NULL
+			AND lr.SpecimenTypeId IN 
+				('CCDA4562-015E-4CA7-B767-45A2940BE4F6',
+				'E3A89A3E-E80D-48D8-9823-76542228AC1C',
+				'44AE75D3-F654-49C2-8F93-DBA9EA74F164', 
+				'579C7E52-F824-4642-BC5D-167E4510BA10')
+		--TODO: exclude culture results?
+		--AND lr.LaboratoryCategoryId = '2D413D16-28E3-48DB-A661-8099226CB6A3'
+	),
+
+	NtbsSputumResults AS
+	(
+		SELECT DISTINCT rr.NotificationId, rr.SourceSystem, FIRST_VALUE(mtr.[Result]) OVER (PARTITION BY rr.NotificationId ORDER BY rra.[Rank]) AS ResultName
+		FROM [$(NTBS)].[dbo].[ManualTestResult] mtr 
+			INNER JOIN [dbo].[RecordRegister] rr ON rr.NotificationId = mtr.NotificationId
+			INNER JOIN ResultRanking rra ON rra.ResultName = mtr.Result
+		WHERE mtr.SampleTypeId IN (4, 5)
+		--TODO: exclude culture results?
+	),
+
+	AllSputumResults AS
+	(
+
+		SELECT * FROM NtbsSputumResults
+		UNION
+		SELECT * FROM EtsSputumResults
+
+	)
+
+	UPDATE cd
+		SET cd.SputumResult = 
+			(CASE ar.ResultName
+				WHEN 'Positive' THEN 'Positive'
+				WHEN 'Negative' THEN 'Negative'
+				ELSE 'Unknown'
+			END)
+
+	FROM [dbo].[Record_CaseData] cd
+		INNER JOIN [dbo].[RecordRegister] rr ON rr.NotificationId = cd.NotificationId
+		LEFT OUTER JOIN AllSputumResults ar ON ar.NotificationId = cd.NotificationId AND ar.SourceSystem = rr.SourceSystem

--- a/source/dbo/Tables/Power BI Reporting/Record_CaseData.sql
+++ b/source/dbo/Tables/Power BI Reporting/Record_CaseData.sql
@@ -56,6 +56,7 @@
 	[DOTReceived] [varchar] (20) NULL,
 	[TestPerformed] [varchar] (10) NULL,
 	[SampleTaken] [varchar] (10) NULL,
+	[SputumResult] [varchar] (20) NULL,
 	[ChestXRayResult] [nvarchar] (100) NULL,
 
 	--outcomes

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -325,6 +325,7 @@
     <Build Include="dbo\Views\Power BI Reporting\vwMissingHospitalMappings.sql" />
     <Build Include="dbo\Views\Power BI Reporting\vwMissingAntibioticMappings.sql" />
     <Build Include="dbo\Views\Power BI Reporting\vwNewAntibioticCodes.sql" />
+    <Build Include="dbo\Stored Procedures\Power BI Reporting\uspGenerateSputumResult.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\RestoreLabbase2.sql" />

--- a/sql-clients/ssrs/Data Migration/Migration Results.rdl
+++ b/sql-clients/ssrs/Data Migration/Migration Results.rdl
@@ -350,6 +350,10 @@ ORDER BY NotificationYear, NtbsRegion</CommandText>
           <DataField>NotificationYear</DataField>
           <rd:TypeName>System.Int32</rd:TypeName>
         </Field>
+        <Field Name="NotificationStatus">
+          <DataField>NotificationStatus</DataField>
+          <rd:TypeName>System.String</rd:TypeName>
+        </Field>
         <Field Name="EtsId">
           <DataField>EtsId</DataField>
           <rd:TypeName>System.String</rd:TypeName>
@@ -3137,6 +3141,9 @@ ORDER BY CountOfRecords DESC</CommandText>
                   <Width>3.00271cm</Width>
                 </TablixColumn>
                 <TablixColumn>
+                  <Width>2.5cm</Width>
+                </TablixColumn>
+                <TablixColumn>
                   <Width>2.96333cm</Width>
                 </TablixColumn>
                 <TablixColumn>
@@ -3276,6 +3283,63 @@ ORDER BY CountOfRecords DESC</CommandText>
                             </Paragraph>
                           </Paragraphs>
                           <rd:DefaultName>Textbox1</rd:DefaultName>
+                          <Style>
+                            <Border>
+                              <Color>Gray</Color>
+                              <Style>Solid</Style>
+                              <Width>0.5pt</Width>
+                            </Border>
+                            <TopBorder>
+                              <Color>Gray</Color>
+                              <Style>Solid</Style>
+                              <Width>0.5pt</Width>
+                            </TopBorder>
+                            <BottomBorder>
+                              <Color>Gray</Color>
+                              <Style>Solid</Style>
+                              <Width>0.5pt</Width>
+                            </BottomBorder>
+                            <LeftBorder>
+                              <Color>Gray</Color>
+                              <Style>Solid</Style>
+                              <Width>0.5pt</Width>
+                            </LeftBorder>
+                            <RightBorder>
+                              <Color>Gray</Color>
+                              <Style>Solid</Style>
+                              <Width>0.5pt</Width>
+                            </RightBorder>
+                            <BackgroundColor>#98002e</BackgroundColor>
+                            <VerticalAlign>Middle</VerticalAlign>
+                            <PaddingLeft>2pt</PaddingLeft>
+                            <PaddingRight>2pt</PaddingRight>
+                            <PaddingTop>2pt</PaddingTop>
+                            <PaddingBottom>2pt</PaddingBottom>
+                          </Style>
+                        </Textbox>
+                      </CellContents>
+                    </TablixCell>
+                    <TablixCell>
+                      <CellContents>
+                        <Textbox Name="Textbox80">
+                          <CanGrow>true</CanGrow>
+                          <KeepTogether>true</KeepTogether>
+                          <Paragraphs>
+                            <Paragraph>
+                              <TextRuns>
+                                <TextRun>
+                                  <Value>Notification Status</Value>
+                                  <Style>
+                                    <FontFamily>Arial</FontFamily>
+                                    <FontWeight>Bold</FontWeight>
+                                    <Color>White</Color>
+                                  </Style>
+                                </TextRun>
+                              </TextRuns>
+                              <Style />
+                            </Paragraph>
+                          </Paragraphs>
+                          <rd:DefaultName>Textbox80</rd:DefaultName>
                           <Style>
                             <Border>
                               <Color>Gray</Color>
@@ -4329,6 +4393,42 @@ ORDER BY CountOfRecords DESC</CommandText>
                     </TablixCell>
                     <TablixCell>
                       <CellContents>
+                        <Textbox Name="NotificationStatus">
+                          <CanGrow>true</CanGrow>
+                          <KeepTogether>true</KeepTogether>
+                          <Paragraphs>
+                            <Paragraph>
+                              <TextRuns>
+                                <TextRun>
+                                  <Value>=Fields!NotificationStatus.Value</Value>
+                                  <Style>
+                                    <FontFamily>Arial</FontFamily>
+                                  </Style>
+                                </TextRun>
+                              </TextRuns>
+                              <Style>
+                                <TextAlign>Left</TextAlign>
+                              </Style>
+                            </Paragraph>
+                          </Paragraphs>
+                          <rd:DefaultName>NotificationStatus</rd:DefaultName>
+                          <Style>
+                            <Border>
+                              <Color>LightGrey</Color>
+                              <Style>Solid</Style>
+                            </Border>
+                            <BackgroundColor>=IIF(RunningValue (Fields!NotificationYear.Value, Count, Nothing) Mod 2 = 1, "White", "#d9e3f2")</BackgroundColor>
+                            <VerticalAlign>Middle</VerticalAlign>
+                            <PaddingLeft>2pt</PaddingLeft>
+                            <PaddingRight>2pt</PaddingRight>
+                            <PaddingTop>2pt</PaddingTop>
+                            <PaddingBottom>2pt</PaddingBottom>
+                          </Style>
+                        </Textbox>
+                      </CellContents>
+                    </TablixCell>
+                    <TablixCell>
+                      <CellContents>
                         <Textbox Name="NotificationDate10">
                           <CanGrow>true</CanGrow>
                           <KeepTogether>true</KeepTogether>
@@ -5027,6 +5127,43 @@ ORDER BY CountOfRecords DESC</CommandText>
                     </TablixCell>
                     <TablixCell>
                       <CellContents>
+                        <Textbox Name="Textbox86">
+                          <CanGrow>true</CanGrow>
+                          <KeepTogether>true</KeepTogether>
+                          <Paragraphs>
+                            <Paragraph>
+                              <TextRuns>
+                                <TextRun>
+                                  <Value />
+                                  <Style>
+                                    <FontFamily>Arial</FontFamily>
+                                    <Color>White</Color>
+                                  </Style>
+                                </TextRun>
+                              </TextRuns>
+                              <Style>
+                                <TextAlign>Left</TextAlign>
+                              </Style>
+                            </Paragraph>
+                          </Paragraphs>
+                          <rd:DefaultName>Textbox86</rd:DefaultName>
+                          <Style>
+                            <Border>
+                              <Color>LightGrey</Color>
+                              <Style>Solid</Style>
+                            </Border>
+                            <BackgroundColor>DimGray</BackgroundColor>
+                            <VerticalAlign>Middle</VerticalAlign>
+                            <PaddingLeft>2pt</PaddingLeft>
+                            <PaddingRight>2pt</PaddingRight>
+                            <PaddingTop>2pt</PaddingTop>
+                            <PaddingBottom>2pt</PaddingBottom>
+                          </Style>
+                        </Textbox>
+                      </CellContents>
+                    </TablixCell>
+                    <TablixCell>
+                      <CellContents>
                         <Textbox Name="Textbox140">
                           <CanGrow>true</CanGrow>
                           <KeepTogether>true</KeepTogether>
@@ -5681,6 +5818,7 @@ ORDER BY CountOfRecords DESC</CommandText>
                 <TablixMember />
                 <TablixMember />
                 <TablixMember />
+                <TablixMember />
               </TablixMembers>
             </TablixColumnHierarchy>
             <TablixRowHierarchy>
@@ -5704,7 +5842,7 @@ ORDER BY CountOfRecords DESC</CommandText>
             <Top>50.18197cm</Top>
             <Left>1.45203cm</Left>
             <Height>2.90187cm</Height>
-            <Width>90.99034cm</Width>
+            <Width>93.49034cm</Width>
             <ZIndex>7</ZIndex>
             <Style>
               <Border>
@@ -11068,7 +11206,7 @@ ORDER BY CountOfRecords DESC</CommandText>
           </Border>
         </Style>
       </Body>
-      <Width>924.42373mm</Width>
+      <Width>949.4237mm</Width>
       <Page>
         <PageFooter>
           <Height>5.34459mm</Height>


### PR DESCRIPTION
Sputum testing is normally done for all pulmonary cases and in some regions it is a KPI which is reviewed at cohort review. We have been asked to add a field to the NTBS [enhanced] line list that summarises the results of all sputum tests for the case.

There is an outstanding question about whether this should exclude culture results (probably) or line probe assay (probably not).  Hence the TODO comments and commented out line in the code.  If we don't hear from the Yorkshire team tomorrow, I will leave it as written and we can hot fix a change if required.

I can't really develop the Power BI report change until I can merge the SQL in.