### PR TITLE
NTBS-2647: Set started treatment to yes if treatment start date populated

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateEtsCaseRecord.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateEtsCaseRecord.sql
@@ -180,7 +180,8 @@ BEGIN TRY
 
 		-- Treatment
 		,dbo.ufnYesNo(te.PostMortemDiagnosis)							AS PostMortemDiagnosis
-		,dbo.ufnYesNo(~te.DidNotStartTreatment)							AS StartedTreatment
+		,CASE WHEN te.StartOfTreatment IS NOT NULL THEN 'Yes'
+			ELSE dbo.ufnYesNo(~te.DidNotStartTreatment) END				AS StartedTreatment
 		,NULL															AS TreatmentRegimen
 		,CONVERT(DATE, tp.MDRTreatmentDate)								AS MdrTreatmentDate
 		,dl.DOTOffered													AS DOTOffered


### PR DESCRIPTION
Changed ETS case record to set started treatment to yes if treatment start date populated.
Not needed for the NTBS case records, as we only allow the input of a date if they have set Started treatment to Yes. 