### PR TITLE
NTBS-2813: Add no result test result

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
@@ -19,7 +19,7 @@ BEGIN TRY
 	INTO #TempManualTestResult
 		FROM RecordRegister rr
 			INNER JOIN [$(NTBS)].[dbo].[ManualTestResult] mtr ON rr.NotificationId = mtr.NotificationId
-		WHERE rr.SourceSystem = 'NTBS' AND mtr.ManualTestTypeId NOT IN (4, 7);
+		WHERE rr.SourceSystem = 'NTBS' AND mtr.ManualTestTypeId NOT IN (4, 7) AND Result <> 'NoResultAvailable';
 
 	WITH venues as (SELECT rr.NotificationId, COUNT(scv.VenueTypeId) AS NumberOfVenues, venues.[Name] AS [Description]
 		FROM RecordRegister rr

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateSputumResult.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateSputumResult.sql
@@ -21,7 +21,7 @@ AS
 		UNION
 		SELECT 4 AS [Rank], 'Not known' AS ResultName
 		UNION
-		SELECT 5 AS [Rank], 'NoResult' AS ResultName
+		SELECT 5 AS [Rank], 'NoResultAvailable' AS ResultName
 	),
 
 	EtsSputumResults AS

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateSputumResult.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateSputumResult.sql
@@ -20,6 +20,8 @@ AS
 		SELECT 3 AS [Rank], 'Awaiting' AS ResultName
 		UNION
 		SELECT 4 AS [Rank], 'Not known' AS ResultName
+		UNION
+		SELECT 5 AS [Rank], 'NoResult' AS ResultName
 	),
 
 	EtsSputumResults AS

--- a/source/dbo/Views/Power BI Reporting/vwLegacyLabExtract.sql
+++ b/source/dbo/Views/Power BI Reporting/vwLegacyLabExtract.sql
@@ -139,7 +139,7 @@ CREATE VIEW [dbo].[vwLegacyLabExtract]
         INNER JOIN [dbo].[Record_CaseData] cd ON cd.NotificationId = rr.NotificationId
         LEFT OUTER JOIN [$(NTBS)].[ReferenceData].ManualTestType tt ON tt.ManualTestTypeId = mtr.ManualTestTypeId
         LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[SampleType] st ON st.SampleTypeId = mtr.SampleTypeId
-    WHERE mtr.ManualTestTypeId != 4 --exclude chest x-ray results
+    WHERE mtr.ManualTestTypeId NOT IN ( 4, 7 ) --exclude chest x-ray/CT results
 
     UNION
     

--- a/source/dbo/Views/Power BI Reporting/vwLegacyLabExtract.sql
+++ b/source/dbo/Views/Power BI Reporting/vwLegacyLabExtract.sql
@@ -103,7 +103,10 @@ CREATE VIEW [dbo].[vwLegacyLabExtract]
 	    END								    AS 'LaboratoryTestType'
         ,st.[Description]				    AS 'Specimen'
         ,mtr.[TestDate]					    AS 'SpecimenDate'
-        ,mtr.[Result]
+        ,CASE
+            WHEN mtr.[Result] = 'NoResultAvailable' THEN 'No result'
+            ELSE mtr.[Result]
+         END                                AS 'Result'
         ,NULL								AS 'Species'
         ,NULL								AS 'SourceLabName'
         ,NULL								AS 'PatientId' 


### PR DESCRIPTION
Also I found a bug, where we hadn't added excluded chest CTs from the legacy lab extract.
Nothing in GenerateCaseData needs to be changed, as we coalesce on "No result", and our query will not pick up "NoResult" (the new result) results. So these will end up as "No result" which is the desired outcome.