### PR TITLE
NTBS-2944: Fix service responsible fields in case data

### DIFF
--- a/source/dbo/Functions/Reusable Notification/ufnGetPeriodicOutcome.sql
+++ b/source/dbo/Functions/Reusable Notification/ufnGetPeriodicOutcome.sql
@@ -54,9 +54,9 @@ SELECT TOP(1)
 	LEFT OUTER JOIN [dbo].[OutcomeLookup] subtype ON subtype.OutcomeCode = tro.TreatmentOutcomeSubType
 	INNER JOIN [dbo].[Outcome] o ON o.NotificationId = te.NotificationId
 	--look for records which are on or after the start of the period
-	WHERE te.EventDate >= DATEADD(YEAR, @TimePeriod-1, o.TreatmentStartDate)
+	WHERE te.EventDate >= DATEADD(YEAR, @TimePeriod-1, o.NotificationStartDate)
 		--and before the end of the period.  Adding a year in this way deals with the problem of leap days
-		AND te.EventDate < DATEADD(YEAR, @TimePeriod, o.TreatmentStartDate)
+		AND te.EventDate < DATEADD(YEAR, @TimePeriod, o.NotificationStartDate)
 		AND te.NotificationId = @NotificationId
 
 	ORDER BY te.EventDate DESC, EventOrder DESC

--- a/source/dbo/Functions/Reusable Notification/ufnGetServiceResponsible.sql
+++ b/source/dbo/Functions/Reusable Notification/ufnGetServiceResponsible.sql
@@ -1,6 +1,6 @@
 ﻿CREATE FUNCTION [dbo].[ufnGetServiceResponsible]
 (
-	@TimePeriod int,
+	@NumberOfYears int,
 	@NotificationId int,
 	@StartDate DATETIME,
 	@DefaultService NVARCHAR(150)
@@ -13,19 +13,10 @@ BEGIN
 	SET @ReturnValue = 
 		COALESCE (
 			(
-			SELECT TOP 1 trans.TbServiceName
-			FROM AllTransfers trans
-			WHERE trans.NotificationId = @NotificationId
-				AND trans.EventDate = DATEADD(DAY, -1, DATEADD(YEAR, @TimePeriod, @StartDate))
-				AND trans.TransferType = 'TransferIn'
-			ORDER BY EventDate DESC
-			),
-			(
-			SELECT TOP 1 trans.TbServiceName
-			FROM AllTransfers trans
-			WHERE trans.NotificationId = @NotificationId
-				AND trans.EventDate >= DATEADD(DAY, -1, DATEADD(YEAR, @TimePeriod, @StartDate))
-				AND trans.TransferType = 'TransferOut'
+			SELECT TOP 1 tout.TbServiceName
+			FROM TransfersOut tout
+			WHERE tout.NotificationId = @NotificationId
+				AND tout.EventDate > DATEADD(DAY, -1, DATEADD(YEAR, @NumberOfYears, @StartDate))
 			ORDER BY EventDate
 			),
 			@DefaultService

--- a/source/dbo/Functions/Reusable Notification/ufnGetServiceResponsible.sql
+++ b/source/dbo/Functions/Reusable Notification/ufnGetServiceResponsible.sql
@@ -1,0 +1,37 @@
+﻿CREATE FUNCTION [dbo].[ufnGetServiceResponsible]
+(
+	@TimePeriod int,
+	@NotificationId int,
+	@StartDate DATETIME,
+	@DefaultService NVARCHAR(150)
+)
+RETURNS NVARCHAR(150)
+AS
+BEGIN
+	DECLARE @ReturnValue NVARCHAR(150) = NULL
+
+	SET @ReturnValue = 
+		COALESCE (
+			(
+			SELECT TOP 1 trans.TbServiceName
+			FROM AllTransfers trans
+			WHERE trans.NotificationId = @NotificationId
+				AND trans.EventDate = DATEADD(DAY, -1, DATEADD(YEAR, @TimePeriod, @StartDate))
+				AND trans.TransferType = 'TransferIn'
+			ORDER BY EventDate DESC
+			),
+			(
+			SELECT TOP 1 trans.TbServiceName
+			FROM AllTransfers trans
+			WHERE trans.NotificationId = @NotificationId
+				AND trans.EventDate >= DATEADD(DAY, -1, DATEADD(YEAR, @TimePeriod, @StartDate))
+				AND trans.TransferType = 'TransferOut'
+			ORDER BY EventDate
+			),
+			@DefaultService
+		)
+
+	RETURN @ReturnValue
+END
+	
+	

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateRecordOutcome.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateRecordOutcome.sql
@@ -49,11 +49,12 @@ BEGIN TRY
 		WHERE TreatmentEventType = 'TransferOut';
 
 	WITH NotifyingServiceAndCodeFromInitialEvent AS
-	(SELECT DISTINCT NotificationId,
+	(SELECT NotificationId,
 		TbServiceCode AS TbServiceCode,
 		tbs.Name AS TbServiceName
 	FROM [$(NTBS)].dbo.TreatmentEvent te
 		JOIN [$(NTBS)].ReferenceData.TbService tbs ON tbs.Code = te.TbServiceCode
+	-- Each notification will have only one of these types of event, never both
 	WHERE te.TreatmentEventType IN ('DiagnosisMade', 'TreatmentStart')),
 
 	NotifyingServiceAndCodeFromTransfer AS

--- a/source/dbo/Stored Procedures/SSRS Reporting/uspGenerateReusableOutcomePeriodic.sql
+++ b/source/dbo/Stored Procedures/SSRS Reporting/uspGenerateReusableOutcomePeriodic.sql
@@ -38,7 +38,7 @@ AS
 		INSERT INTO [dbo].PeriodicOutcome (NotificationId, TimePeriod, OutcomeValue, DescriptiveOutcome, IsFinal)
 			SELECT NotificationId, @TimePeriod, 'No outcome recorded', 'No outcome recorded', 0  FROM [dbo].[Outcome] o 
 			--find the records that are old enough for inclusion - they should be older by at least one day than the end of the previous time period
-			WHERE GETUTCDATE() > DATEADD(YEAR, @TimePeriod-1, o.TreatmentStartDate)
+			WHERE GETUTCDATE() > DATEADD(YEAR, @TimePeriod-1, o.NotificationStartDate)
 			--and the previous period's outcome was non-final
 			AND o.NotificationId IN 
 			(SELECT po.NotificationId FROM [dbo].[PeriodicOutcome] po 

--- a/source/dbo/Tables/Reusable Notification/AllTransfers.sql
+++ b/source/dbo/Tables/Reusable Notification/AllTransfers.sql
@@ -1,8 +1,0 @@
-﻿CREATE TABLE [dbo].[AllTransfers]
-(
-	[NotificationId] INT NULL,
-	EventDate DATE NULL,
-	TbServiceCode NVARCHAR(15) NULL,
-	TbServiceName NVARCHAR(150) NULL,
-	TransferType NVARCHAR(20) NULL
-)

--- a/source/dbo/Tables/Reusable Notification/AllTransfers.sql
+++ b/source/dbo/Tables/Reusable Notification/AllTransfers.sql
@@ -1,0 +1,8 @@
+﻿CREATE TABLE [dbo].[AllTransfers]
+(
+	[NotificationId] INT NULL,
+	EventDate DATE NULL,
+	TbServiceCode NVARCHAR(15) NULL,
+	TbServiceName NVARCHAR(150) NULL,
+	TransferType NVARCHAR(20) NULL
+)

--- a/source/dbo/Tables/Reusable Notification/Outcome.sql
+++ b/source/dbo/Tables/Reusable Notification/Outcome.sql
@@ -2,7 +2,7 @@
 (
 	[OutcomeId] [int] IDENTITY(1,1) NOT NULL, 
     [NotificationId] INT NOT NULL, 
-    [TreatmentStartDate] DATETIME NULL, 
+    [NotificationStartDate] DATETIME NULL, 
    
     CONSTRAINT [PK_Outcome] PRIMARY KEY ([OutcomeId])
 )

--- a/source/dbo/Tables/Reusable Notification/TransfersOut.sql
+++ b/source/dbo/Tables/Reusable Notification/TransfersOut.sql
@@ -1,0 +1,7 @@
+﻿CREATE TABLE [dbo].[TransfersOut]
+(
+	[NotificationId] INT NULL,
+	EventDate DATE NULL,
+	TbServiceCode NVARCHAR(15) NULL,
+	TbServiceName NVARCHAR(150) NULL
+)

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -331,6 +331,8 @@
     <Build Include="dbo\Views\Power BI Reporting\vwDrugResistanceProfiles.sql" />
     <Build Include="dbo\Stored Procedures\SSRS Reporting\uspUpdateOutcomesForPostMortemCases.sql" />
     <Build Include="dbo\Views\Power BI Reporting\vwServiceDirectory.sql" />
+    <Build Include="dbo\Tables\Reusable Notification\AllTransfers.sql" />
+    <Build Include="dbo\Functions\Reusable Notification\ufnGetServiceResponsible.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\RestoreLabbase2.sql" />

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -331,7 +331,7 @@
     <Build Include="dbo\Views\Power BI Reporting\vwDrugResistanceProfiles.sql" />
     <Build Include="dbo\Stored Procedures\SSRS Reporting\uspUpdateOutcomesForPostMortemCases.sql" />
     <Build Include="dbo\Views\Power BI Reporting\vwServiceDirectory.sql" />
-    <Build Include="dbo\Tables\Reusable Notification\AllTransfers.sql" />
+    <Build Include="dbo\Tables\Reusable Notification\TransfersOut.sql" />
     <Build Include="dbo\Functions\Reusable Notification\ufnGetServiceResponsible.sql" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Only generate a "service responsible at X months" if there is an outcome at X months (for 24 and 36, 12 is always calculated).
Brought the logic into it's own function.
Fixed the case where there is a transfer on the day of the outcome.