### PR TITLE
NTBS-2987 Add SQL CMD variable for number of reporting years

### DIFF
--- a/source/Publish Profiles/Pre-production/azure-int-reporting.publish.xml
+++ b/source/Publish Profiles/Pre-production/azure-int-reporting.publish.xml
@@ -99,6 +99,9 @@
     <SqlCmdVariable Include="NTBS_Specimen_Matching">
       <Value>int-specimen-matching</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="NumberOfReportingYears">
+      <Value>5</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="ReportServer">
       <Value>ReportServer</Value>
     </SqlCmdVariable>

--- a/source/Publish Profiles/Pre-production/azure-test-reporting.publish.xml
+++ b/source/Publish Profiles/Pre-production/azure-test-reporting.publish.xml
@@ -99,6 +99,9 @@
     <SqlCmdVariable Include="NTBS_Specimen_Matching">
       <Value>test-specimen-matching</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="NumberOfReportingYears">
+      <Value>5</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="ReportServer">
       <Value>ReportServer</Value>
     </SqlCmdVariable>

--- a/source/Publish Profiles/Pre-production/phe-dev-reporting.publish.xml
+++ b/source/Publish Profiles/Pre-production/phe-dev-reporting.publish.xml
@@ -99,6 +99,9 @@
     <SqlCmdVariable Include="NTBS_Specimen_Matching">
       <Value>NTBS_Specimen_Matching</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="NumberOfReportingYears">
+      <Value>5</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="ReportServer">
       <Value>ReportServer</Value>
     </SqlCmdVariable>

--- a/source/Publish Profiles/Pre-production/phe-uat-reporting.publish.xml
+++ b/source/Publish Profiles/Pre-production/phe-uat-reporting.publish.xml
@@ -99,6 +99,9 @@
     <SqlCmdVariable Include="NTBS_Specimen_Matching">
       <Value>NTBS_Specimen_Matching_UAT</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="NumberOfReportingYears">
+      <Value>2</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="ReportServer">
       <Value>NTBS_ReportServer_UAT</Value>
     </SqlCmdVariable>

--- a/source/Publish Profiles/Production/phe-live-reporting.publish.xml
+++ b/source/Publish Profiles/Production/phe-live-reporting.publish.xml
@@ -99,6 +99,9 @@
     <SqlCmdVariable Include="NTBS_Specimen_Matching">
       <Value>NTBS_Specimen_Matching_Live</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="NumberOfReportingYears">
+      <Value>5</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="ReportServer">
       <Value>NTBS_ReportServer_Live</Value>
     </SqlCmdVariable>

--- a/source/dbo/Views/Reusable Drop Downs/vwNotificationYear.sql
+++ b/source/dbo/Views/Reusable Drop Downs/vwNotificationYear.sql
@@ -34,4 +34,5 @@ CREATE VIEW [dbo].[vwNotificationYear] AS
 				-4 AS Id,
 				YEAR(DATEADD(YEAR, DATEDIFF(YEAR, 0, GETDATE()) -4, 0)) AS NotificationYear
 		) NotificationYear
+	WHERE Id > CONVERT(INT, '-$(NumberOfReportingYears)')
 	ORDER BY NotificationYear DESC

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -439,6 +439,10 @@
       <DefaultValue>$(ReportServer)</DefaultValue>
       <Value>$(SqlCmdVar__14)</Value>
     </SqlCmdVariable>
+    <SqlCmdVariable Include="NumberOfReportingYears">
+      <DefaultValue>5</DefaultValue>
+      <Value>$(SqlCmdVar__22)</Value>
+    </SqlCmdVariable>
     <SqlCmdVariable Include="ReportServer">
       <DefaultValue>ReportServer</DefaultValue>
       <Value>$(SqlCmdVar__14)</Value>


### PR DESCRIPTION
Allow us to set the number of reporting years of data in the publish profile, so that we can change it on a per-environment basis