### PR TITLE
NTBS-1526: initial view for service directory report

### DIFF
--- a/source/dbo/Views/Power BI Reporting/vwServiceDirectory.sql
+++ b/source/dbo/Views/Power BI Reporting/vwServiceDirectory.sql
@@ -1,0 +1,26 @@
+﻿CREATE VIEW [dbo].[vwServiceDirectory]
+	AS
+	SELECT 
+		p.Code AS RegionCode,
+		p.Name AS Region,
+		tbs.Code AS TbServiceCode,
+		tbs.Name AS TbServiceName,
+		[DisplayName]
+		,[Notes]
+		,COALESCE([EmailPrimary], u.[Username]) AS EmailAddress
+		,[EmailSecondary]
+		,[JobTitle]
+		,[PhoneNumberPrimary]
+		,[PhoneNumberSecondary]
+		,Q1.LastLoggedIn
+	FROM [$(NTBS)].[dbo].[User] u
+		INNER JOIN [dbo].[vwUserPermissions] up ON up.upn = u.Username
+		LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[TbService] tbs ON tbs.Code = up.Code
+		LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[PHEC] p ON p.Code = up.Region
+		LEFT OUTER JOIN 
+			(SELECT 
+				Username, 
+				MAX(LoginDate) AS LastLoggedIn 
+			FROM [$(NTBS)].[dbo].[UserLoginEvent]
+			GROUP BY Username) AS Q1 ON Q1.Username = u.Username
+	WHERE IsActive = 1 AND up.Region IS NOT NULL and u.Username NOT LIKE '%softwire.com%'

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -330,6 +330,7 @@
     <Build Include="dbo\Views\Power BI Reporting\vwMissingCohortReviewItems.sql" />
     <Build Include="dbo\Views\Power BI Reporting\vwDrugResistanceProfiles.sql" />
     <Build Include="dbo\Stored Procedures\SSRS Reporting\uspUpdateOutcomesForPostMortemCases.sql" />
+    <Build Include="dbo\Views\Power BI Reporting\vwServiceDirectory.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\RestoreLabbase2.sql" />


### PR DESCRIPTION
The service directory report will display information about regions and their staff + TB services and their staff, including contact details.  New view to expose the right data to Power BI.
It doesn't include the national team because their individual contact details have never been included in the service directory. I have put in a clause to exclude Softwire staff from being displayed because @JoshCadney has a London regional role which is really useful for testing but we don't want him to appear in the service directory.