### PR TITLE
NTBS-2981

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateRecordOutcome.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateRecordOutcome.sql
@@ -95,6 +95,14 @@ BEGIN TRY
 		LEFT OUTER JOIN [dbo].[PeriodicOutcome] po3 ON po3.NotificationId = o.NotificationId AND po3.TimePeriod = 3
 	WHERE rr.SourceSystem = 'NTBS'
 
+	--finally update the notifying region
+
+	UPDATE cd
+	SET
+		NotifyingRegionCode = tbs.PHECCode
+	FROM [dbo].[Record_CaseData] cd
+		INNER JOIN [$(NTBS)].ReferenceData.TbService tbs ON tbs.Code = cd.NotifyingTbServiceCode
+
 
 	--finally delete this table. TODO: Leave commented out for now for debugging
 	--DELETE FROM [dbo].[Outcome]

--- a/source/dbo/Tables/Power BI Reporting/Record_CaseData.sql
+++ b/source/dbo/Tables/Power BI Reporting/Record_CaseData.sql
@@ -15,6 +15,7 @@
 	[TbService] [nvarchar](150) NULL,
 	[NotifyingTbService] [nvarchar](150) NULL,
 	[NotifyingTbServiceCode] [nvarchar](15) NULL,
+	[NotifyingRegionCode] [nvarchar](15) NULL,
 	[Age] [tinyint] NULL,
 	[Sex] [varchar](10) NULL,
 	[UkBorn] [varchar](10) null,


### PR DESCRIPTION
Added 'notifying region code' so that we can ensure regional users can also access cases no longer in their region  but notified there.

I did it as a separate update because the calculation of the TB service code used to look up the region code is quite complicated.