### PR TITLE
NTBS-2997 - add descriptive outcome for post-mortem cases

### DIFF
--- a/source/dbo/Stored Procedures/SSRS Reporting/uspUpdateOutcomesForPostMortemCases.sql
+++ b/source/dbo/Stored Procedures/SSRS Reporting/uspUpdateOutcomesForPostMortemCases.sql
@@ -1,11 +1,11 @@
 ﻿CREATE PROCEDURE [dbo].[uspUpdateOutcomesForPostMortemCases]
 AS
 BEGIN TRY
-	UPDATE po SET OutcomeValue = 'Died', IsFinal = 1
+	UPDATE po SET OutcomeValue = ol.OutcomeDescription, DescriptiveOutcome = CONCAT(ol.OutcomeDescription, ' - ', subtype.OutcomeDescription), IsFinal = 1
 	FROM [dbo].PeriodicOutcome po
-	WHERE po.NotificationId IN
+	INNER JOIN 
 		(
-		SELECT DISTINCT te.NotificationId
+		SELECT DISTINCT te.NotificationId, te.TreatmentOutcomeId
 		FROM [$(NTBS)].dbo.TreatmentEvent te
 			LEFT JOIN [$(NTBS)].dbo.TreatmentEvent te2 ON te2.NotificationId = te.NotificationId AND te.EventDate <= te2.EventDate
 			LEFT JOIN [$(NTBS)].dbo.TreatmentEvent te3 ON te3.NotificationId = te.NotificationId
@@ -16,8 +16,11 @@ BEGIN TRY
 			AND te.TreatmentOutcomeId IN (7, 8, 9, 10)
 			AND (te2.TreatmentEventType = 'DiagnosisMade' OR te2.TreatmentEventId IS NULL)
 			AND te3.TreatmentEventId IS NULL
-		)
-		AND TimePeriod = 1
+		) AS Q1 ON Q1.NotificationId = po.NotificationId
+	LEFT OUTER JOIN [$(NTBS)].[ReferenceData].[TreatmentOutcome] tro ON tro.TreatmentOutcomeId = Q1.TreatmentOutcomeId
+	LEFT OUTER JOIN [dbo].[OutcomeLookup] ol ON ol.OutcomeCode = tro.TreatmentOutcomeType
+	LEFT OUTER JOIN [dbo].[OutcomeLookup] subtype ON subtype.OutcomeCode = tro.TreatmentOutcomeSubType
+	WHERE TimePeriod = 1
 
 END TRY
 BEGIN CATCH


### PR DESCRIPTION
I realised when testing NTBS-2973 that the correct outcome for post-mortem cases is being set after `[uspGenerateReusableOutcomePeriodic]` is called for period 1, meaning the new 'descriptive' outcome fields are not set to the right value for post-mortem cases.

I added the logic used to return both the short and long outcome descriptions into` [uspUpdateOutcomesForPostMortemCases]`. It reproduces some of the logic in `ufnGetPeriodicOutcome` but I think it's the best way to handle it, given we make a special case for post-mortem case outcomes anyway.