### PR TITLE
NTBS-3010: Deal with null in subtype of outcome

### DIFF
--- a/source/dbo/Functions/Reusable Notification/ufnGetPeriodicOutcome.sql
+++ b/source/dbo/Functions/Reusable Notification/ufnGetPeriodicOutcome.sql
@@ -36,8 +36,8 @@ SELECT TOP(1)
 		END) AS EventOrder,
 	--calculate whether the event is an ending one or not
 	(CASE 
-		WHEN tro.TreatmentOutcomeSubType <> 'StillOnTreatment' THEN 1
-		ELSE 0
+		WHEN tro.TreatmentOutcomeSubType = 'StillOnTreatment' THEN 0
+		ELSE 1
 		END) AS EndingEvent,
 	 COALESCE(ol.OutcomeDescription, 'No outcome recorded') AS 'OutcomeValue',
 	 tro.TreatmentOutcomeSubType,


### PR DESCRIPTION
Treatment outcome 14 is the only outcome that has a NULL in the subtype column, this wasn't playing nicely with `<>` so it wasn't being seen as an ending outcome. Switching to an equality check has solved that