### PR TITLE
NTBS-3071: Make test result summaries consistent

### DIFF
--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateInitialSputumResults.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateInitialSputumResults.sql
@@ -3,17 +3,6 @@ CREATE PROCEDURE [dbo].[uspGenerateInitialSputumResults]
 AS
 	WITH
 
-	ResultRanking AS
-	(
-		SELECT 1 AS Rank, 1 AS SubRank, 'Positive' AS ResultName, 'Positive' AS DisplayName
-		UNION
-		SELECT 1 AS Rank, 2 AS SubRank, 'Negative' AS ResultName, 'Negative' AS ResultName
-		UNION
-		SELECT 2 AS Rank, NULL AS SubRank, 'NoResultAvailable' AS ResultName, 'No result available' AS ResultName
-		UNION
-		SELECT 3 AS Rank, NULL AS SubRank, 'Awaiting' AS ResultName, 'Awaiting' AS ResultName
-	),
-
 	NtbsInitialSputumSmearResults AS 
 	(
 		SELECT DISTINCT 
@@ -22,7 +11,7 @@ AS
            	FIRST_VALUE(rra.[DisplayName]) OVER (PARTITION BY rr.NotificationId ORDER BY rra.[Rank], mtr.TestDate, rra.[SubRank]) AS InitialSputumSmearResult
 		FROM [$(NTBS)].[dbo].[ManualTestResult] mtr
 			JOIN [dbo].[RecordRegister] rr on rr.NotificationId = mtr.NotificationId
-			INNER JOIN ResultRanking rra ON rra.ResultName = mtr.Result
+			INNER JOIN ManualTestResultRanking rra ON rra.ResultName = mtr.Result
 		WHERE mtr.ManualTestTypeId=1 
 		AND mtr.SampleTypeId IN (4,5) 
 		AND rr.SourceSystem='NTBS'
@@ -36,7 +25,7 @@ AS
            	FIRST_VALUE(rra.[DisplayName]) OVER (PARTITION BY rr.NotificationId ORDER BY rra.[Rank], mtr.TestDate, rra.[SubRank]) AS InitialSputumPCRResult
 		FROM [$(NTBS)].[dbo].[ManualTestResult] mtr
 			JOIN [dbo].[RecordRegister] rr on rr.NotificationId = mtr.NotificationId
-			INNER JOIN ResultRanking rra ON rra.ResultName = mtr.Result
+			INNER JOIN ManualTestResultRanking rra ON rra.ResultName = mtr.Result
 		WHERE mtr.ManualTestTypeId=5 
 		AND mtr.SampleTypeId IN (4,5) 
 		AND rr.SourceSystem='NTBS'

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateNtbsCaseRecord.sql
@@ -381,7 +381,7 @@ BEGIN TRY
 	DROP TABLE #TempDiseaseSites
 	DROP TABLE #TempSocialContextVenues
 
-	--'Sample taken' should be set if there are any manually-entered test results which are NOT of type chest x-ray
+	--'Sample taken' should be set if there are any manually-entered test results which are NOT of type chest x-ray or chest CT
 	UPDATE cd
 		SET SampleTaken = CASE WHEN manualresults.NotificationId IS NULL THEN 'No' ELSE 'Yes' END
 
@@ -390,7 +390,7 @@ BEGIN TRY
 			SELECT mr.NotificationId
 			FROM [$(NTBS)].[dbo].[ManualTestResult] mr
 				INNER JOIN [dbo].[Record_CaseData] cd ON cd.NotificationId = mr.NotificationId
-			WHERE ManualTestTypeId != 4
+			WHERE ManualTestTypeId NOT IN (4, 7)
 			) AS manualresults ON manualresults.NotificationId = cd.NotificationId
 
 	EXEC [dbo].uspGenerateRecordOutcome

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingCaseData.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateReportingCaseData.sql
@@ -8,8 +8,7 @@ BEGIN TRY
 	
 	--finally do stuff that makes sense just to do for all records, like the last recorded treatment outcome 
 
-	EXEC [dbo].[uspGenerateSputumResult]
-    	EXEC [dbo].[uspGenerateInitialSputumResults]
+	EXEC [dbo].[uspGenerateTestResultSummaries]
 
 	UPDATE cd 
 	SET AnySocialRiskFactor = CASE 

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateTestResultSummaries.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspGenerateTestResultSummaries.sql
@@ -1,0 +1,46 @@
+﻿CREATE PROCEDURE [dbo].[uspGenerateTestResultSummaries]
+
+AS
+	EXEC [dbo].[uspGenerateSputumResult];
+    EXEC [dbo].[uspGenerateInitialSputumResults];
+
+	SELECT DISTINCT rr.NotificationId, ManualTestTypeId,
+		FIRST_VALUE(rra.DisplayName) OVER (PARTITION BY rr.NotificationId, mtr.ManualTestTypeId ORDER BY
+			rra.[Rank], mtr.TestDate, rra.[SubRank]) AS Result
+	INTO #TempManualTestResult
+		FROM RecordRegister rr
+			INNER JOIN [$(NTBS)].[dbo].[ManualTestResult] mtr ON rr.NotificationId = mtr.NotificationId
+			INNER JOIN ManualTestResultRanking rra ON rra.ResultName = mtr.Result
+		WHERE rr.SourceSystem = 'NTBS' AND mtr.ManualTestTypeId NOT IN (4, 7);
+
+	UPDATE cd
+    SET cd.SmearSummary =
+            COALESCE(
+				(SELECT Result FROM #TempManualTestResult tmtr
+					WHERE tmtr.NotificationId = rr.NotificationId AND ManualTestTypeId = 1)
+				,'No result'),
+        cd.CultureSummary =
+            COALESCE(
+				(SELECT Result FROM #TempManualTestResult tmtr
+					WHERE tmtr.NotificationId = rr.NotificationId AND ManualTestTypeId = 2)
+				,'No result'),
+		cd.HistologySummary =
+            COALESCE(
+				(SELECT Result FROM #TempManualTestResult tmtr
+					WHERE tmtr.NotificationId = rr.NotificationId AND ManualTestTypeId = 3)
+				,'No result'),
+		cd.PCRSummary =
+            COALESCE(
+				(SELECT Result FROM #TempManualTestResult tmtr
+					WHERE tmtr.NotificationId = rr.NotificationId AND ManualTestTypeId = 5)
+				,'No result'),
+		cd.LineProbeAssaySummary =
+            COALESCE(
+				(SELECT Result FROM #TempManualTestResult tmtr
+					WHERE tmtr.NotificationId = rr.NotificationId AND ManualTestTypeId = 6)
+				,'No result')
+    FROM [dbo].[Record_CaseData] cd
+        INNER JOIN [dbo].[RecordRegister] rr ON rr.NotificationId = cd.NotificationId
+	WHERE rr.SourceSystem = 'NTBS'
+    
+	DROP TABLE #TempManualTestResult;

--- a/source/dbo/Stored Procedures/Power BI Reporting/uspPopulateLookupTables.sql
+++ b/source/dbo/Stored Procedures/Power BI Reporting/uspPopulateLookupTables.sql
@@ -22,6 +22,14 @@ BEGIN TRY
 	('DotRefused', NULL, 'DOT refused'),
 	('Unknown', NULL, 'Unknown')
 
+	TRUNCATE TABLE [dbo].[ManualTestResultRanking];
+	INSERT INTO [dbo].[ManualTestResultRanking](Rank, SubRank, ResultName, DisplayName)
+	VALUES
+	(1, 1, 'Positive', 'Positive'),
+	(1, 2, 'Negative', 'Negative'),
+	(2, NULL, 'NoResultAvailable', 'No result available'),
+	(3, NULL, 'Awaiting', 'Awaiting')
+
 	TRUNCATE TABLE [dbo].[ChestTestResultLookup]
 	INSERT INTO [dbo].[ChestTestResultLookup](Ranking, Result, FormattedResult)
 	VALUES

--- a/source/dbo/Tables/Power BI Reporting/ManualTestResultRanking.sql
+++ b/source/dbo/Tables/Power BI Reporting/ManualTestResultRanking.sql
@@ -1,0 +1,7 @@
+﻿CREATE TABLE [dbo].[ManualTestResultRanking]
+(
+	[Rank] INT NOT NULL,
+	[SubRank] INT NULL,
+	[ResultName] NVARCHAR(MAX) NOT NULL,
+	[DisplayName] NVARCHAR(MAX) NOT NULL
+)

--- a/source/ntbs-reporting.sqlproj
+++ b/source/ntbs-reporting.sqlproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -10,8 +10,7 @@
     <ProjectGuid>{00903ab8-5be1-4195-9677-566baa463341}</ProjectGuid>
     <DSP>Microsoft.Data.Tools.Schema.Sql.Sql140DatabaseSchemaProvider</DSP>
     <OutputType>Database</OutputType>
-    <RootPath>
-    </RootPath>
+    <RootPath />
     <RootNamespace>Reporting_New</RootNamespace>
     <AssemblyName>Reporting_New</AssemblyName>
     <ModelCollation>1033,CI</ModelCollation>
@@ -52,7 +51,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
-    <!-- Default to the v11.0 targets path if the targets file for the current VS version is not found -->
     <SSDTExists Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\SSDT\Microsoft.Data.Tools.Schema.SqlTasks.targets')">True</SSDTExists>
     <VisualStudioVersion Condition="'$(SSDTExists)' == ''">11.0</VisualStudioVersion>
   </PropertyGroup>
@@ -340,6 +338,8 @@
     <None Include="Scripts\SetEnvironment.sql" />
     <Build Include="dbo\Tables\Power BI Reporting\Environment.sql" />
     <Build Include="dbo\Views\Power BI Reporting\vwApplicationUsage.sql" />
+    <Build Include="dbo\Stored Procedures\Power BI Reporting\uspGenerateTestResultSummaries.sql" />
+    <Build Include="dbo\Tables\Power BI Reporting\ManualTestResultRanking.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\RestoreLabbase2.sql" />


### PR DESCRIPTION
Made the ranking a lookup table, as it is used in a few different places. 
Made the logic for all the different test result summaries consistent (with how we do it for the `Initial...` fields)