### PR TITLE
NTBS-3094 fix spelling error for data quality alert

### DIFF
--- a/source/dbo/Stored Procedures/Data Migration/uspMigrationDuplicateAlerts.sql
+++ b/source/dbo/Stored Procedures/Data Migration/uspMigrationDuplicateAlerts.sql
@@ -20,7 +20,7 @@ AS
 			INNER JOIN [$(NTBS)].[dbo].[Notification] duplicate on duplicate.NotificationId = a.DuplicateId
 			LEFT JOIN [dbo].[MigrationRunResults] dupmrr ON dupmrr.LegacyETSId = duplicate.ETSID
 		WHERE AlertStatus = 'Open'
-			AND AlertType = 'DataQualityPotientialDuplicate'
+			AND AlertType = 'DataQualityPotentialDuplicate'
 			AND mrr.MigrationRunId = @MigrationRun
 	) 
 	SELECT


### PR DESCRIPTION
Fix the data quality alert for a potential duplicate being misspelled as “DataQualityPotientialDuplicate”.

There is also a PR for the ntbs_Beta repo with the application changes.

